### PR TITLE
Add cosmic greeter sysuser and tmpfile configurations for systemd-sysusers and systemd-tmpfiles

### DIFF
--- a/debian/cosmic-greeter-sysusers.conf
+++ b/debian/cosmic-greeter-sysusers.conf
@@ -1,0 +1,2 @@
+#Type Name           ID GECOS                    Home directory           Shell
+u     cosmic-greeter -  "Cosmic Greeter Account" /var/lib/cosmic-greeter  -

--- a/debian/cosmic-greeter-tmpfiles.conf
+++ b/debian/cosmic-greeter-tmpfiles.conf
@@ -1,0 +1,2 @@
+# Home directory of cosmic-greeter
+d	/var/lib/cosmic-greeter	0750	cosmic-greeter	cosmic-greeter

--- a/justfile
+++ b/justfile
@@ -11,6 +11,16 @@ export INSTALL_DIR := base-dir / 'share'
 bin-src := 'target' / 'release' / name
 bin-dst := base-dir / 'bin' / name
 
+# Systemd sysusers/tmpfiles components directories
+lib-dir := base-dir / 'lib'
+
+# sysusers.d
+sysusers-src := 'debian' / 'cosmic-greeter-sysusers.conf'
+sysusers-dst := lib-dir / 'sysusers.d' / name + '.conf'
+# tmpfiles.d
+tmpfiles-src := 'debian' / 'cosmic-greeter-tmpfiles.conf'
+tmpfiles-dst := lib-dir / 'tmpfiles.d' / name + '.conf'
+
 daemon-src := 'target' / 'release' / name + '-daemon'
 daemon-dst := base-dir / 'bin' / name + '-daemon'
 
@@ -54,10 +64,12 @@ install:
     install -Dm0755 {{bin-src}} {{bin-dst}}
     install -Dm0755 {{daemon-src}} {{daemon-dst}}
     install -Dm0755 {{dbus-src}} {{dbus-dst}}
+    install -Dm0644 {{sysusers-src}} {{sysusers-dst}}
+    install -Dm0644 {{tmpfiles-src}} {{tmpfiles-dst}}
 
 # Uninstalls installed files
 uninstall:
-    rm {{bin-dst}} {{daemon-dst}} {{dbus-dst}}
+    rm {{bin-dst}} {{daemon-dst}} {{dbus-dst}} {{sysusers-dst}} {{tmpfiles-dst}}
 
 # Vendor dependencies locally
 vendor:


### PR DESCRIPTION
~~This is currently a draft while I test to make sure this file works as intended.~~ it works as intended
Fixes https://github.com/pop-os/cosmic-greeter/issues/11


This PR creates a `systemd-sysusers` configuration file and a `systemd-tmpfiles` configuration file.
The sysusers configuration file will tell systemd-sysusers to automatically create and clear a `cosmic-greeter` user on boot. This file must be placed in `/usr/lib/sysusers.d/`
The tmpfiles configuration file will tell systemd-tmpfiles to automatically create a specified directory (in this case cosmic-greeter's home directory). This file must be placed in `/usr/lib/tmpfiles.d/`

This will allow immutable/atomic distributions to make better use of `cosmic-greeter`.

References:
https://www.freedesktop.org/software/systemd/man/latest/sysusers.d.html#
https://www.freedesktop.org/software/systemd/man/latest/tmpfiles.d.html#
I used https://github.com/sddm/sddm/blob/develop/services/sddm-sysuser.conf.in and https://github.com/sddm/sddm/blob/develop/services/sddm-tmpfiles.conf.in as a reference to make these files, also see the conversation in #11 for why this is needed on other distros.

CC @jokeyrhyme 