### PR TITLE
Search all XDG_DATA_DIRS and XDG_DATA_HOME for sessions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -825,6 +825,7 @@ dependencies = [
  "tokio",
  "upower_dbus",
  "wayland-client 0.31.1",
+ "xdg",
  "zbus",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ pam-client = "0.5.0"
 pwd.workspace = true
 ron.workspace = true
 shlex = "1.2.0"
+xdg = "2.5.2"
 #TODO: reduce features
 tokio = { workspace = true, features = ["full"] }
 wayland-client = "0.31.1"


### PR DESCRIPTION
Searching from the environment allows using on distributions that do not store login sessions in `/usr/share` (e.g. NixOS)