### PR TITLE
Fix power_off in logind.rs

### DIFF
--- a/src/logind.rs
+++ b/src/logind.rs
@@ -4,7 +4,7 @@ use zbus::{Connection, Result};
 pub async fn power_off() -> Result<()> {
     let connection = Connection::system().await?;
     let manager = ManagerProxy::new(&connection).await?;
-    manager.reboot(false).await
+    manager.power_off(false).await
 }
 
 pub async fn reboot() -> Result<()> {


### PR DESCRIPTION
Updates `power_off` in `logind.rs` to use `manager.power_off()` instead of `manager.reboot()`. 

I suppose this is a typo made while copy pasting?