### PR TITLE
fix: enable cosmic-greeter-daemon when cosmic-greeter is enabled

### DIFF
--- a/debian/cosmic-greeter.service
+++ b/debian/cosmic-greeter.service
@@ -3,6 +3,7 @@ Description=COSMIC Greeter
 After=systemd-user-sessions.service plymouth-quit-wait.service cosmic-greeter-daemon.service
 After=getty@tty1.service
 Conflicts=getty@tty1.service
+Wants=cosmic-greeter-daemon.service
 
 [Service]
 Type=simple


### PR DESCRIPTION
This change ensures that the cosmic-greeter-daemon is enabled along with the cosmic-greeter service, ensuring that both are utilized in end user setups. This will reduce the likelihood that someone reports a bug due to the greeter daemon not running.

Wants implies a soft dependency, so if the greeter daemon isn't installed or doesn't work, the greeter can still function.