### PR TITLE
fix(daemon): require daemon in greeter, give daemon type dbus

### DIFF
--- a/debian/cosmic-greeter-daemon.service
+++ b/debian/cosmic-greeter-daemon.service
@@ -2,6 +2,8 @@
 Description=COSMIC Greeter Daemon
 
 [Service]
+Type=dbus
+BusName=com.system76.CosmicGreeter
 ExecStart=/usr/bin/cosmic-greeter-daemon
 Restart=on-failure
 

--- a/debian/cosmic-greeter.service
+++ b/debian/cosmic-greeter.service
@@ -3,7 +3,7 @@ Description=COSMIC Greeter
 After=systemd-user-sessions.service plymouth-quit-wait.service cosmic-greeter-daemon.service
 After=getty@tty1.service
 Conflicts=getty@tty1.service
-Wants=cosmic-greeter-daemon.service
+Requires=cosmic-greeter-daemon.service
 
 [Service]
 Type=simple


### PR DESCRIPTION
This PR will fix race conditions in which the cosmic-greeter service starts before the cosmic-greeter-daemon can acquire a bus name. However, it should be noted that now that greeter requires the daemon, it won't start *unless* the daemon is able to start.