### PR TITLE
Fix login deadlocks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2150,9 +2150,11 @@ version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1600ad23798daf53f5c336ebca8a7c603696ef4455103e9c713fab574131eb35"
 dependencies = [
+ "async-trait",
  "serde",
  "serde_json",
  "thiserror",
+ "tokio",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ rust-embed = "8"
 
 [dependencies.greetd_ipc]
 version = "0.10.0"
-features = ["sync-codec"]
+features = ["tokio-codec"]
 
 [features]
 default = ["logind", "networkmanager", "upower"]


### PR DESCRIPTION
Logins seem to spuriously fail with both correct or incorrect passwords. The failure is not related to the password itself. `cosmic-greeter` hangs but the GUI still works. The password text area disappears as well.

I traced this issue down to the socket. It seems like accessing the socket deadlocks with one thread waiting for the socket to become readable while another waits for it to become writable.

Switching to `greet-ipc`'s `TokioCodec` and adding a lock to the socket seems to have fixed this issue. I successfully logged in and inputted incorrect passwords consecutively without experiencing a deadlock.

![hang_02](https://github.com/pop-os/cosmic-greeter/assets/48846352/4f0ccce9-bca6-4cdd-81e4-f46271896f09)
Login hang on a correct password.

![hang_03](https://github.com/pop-os/cosmic-greeter/assets/48846352/53c4f5e3-56a2-420e-a844-db8ea2c7af3f)
This picture is from the same login as above. The session never starts, but the UI itself isn't frozen as the clock and shutdown timer indicate.

![hang_01](https://github.com/pop-os/cosmic-greeter/assets/48846352/ce66d695-0650-47c2-ba03-8c8c7d0cae77)
Login hang on an incorrect password.

I'm not sure, but it seems like issue #12 is related.