### PR TITLE
Add an indication that battery's missing

### DIFF
--- a/src/greeter.rs
+++ b/src/greeter.rs
@@ -1025,9 +1025,8 @@ impl cosmic::Application for App {
 
             if let Some((power_icon, power_percent)) = &self.power_info_opt {
                 status_row = status_row.push(iced::widget::row![
-                    widget::icon::from_name(power_icon.clone()),
                     widget::text(if power_percent == &0.0 {
-                        format!("System is running from the wall or the battery")
+                        format!("")
                     } else {
                         widget::icon::from_name(power_icon.clone());
                         format!("{:.0}%", power_percent)

--- a/src/greeter.rs
+++ b/src/greeter.rs
@@ -345,7 +345,7 @@ async fn request_message(socket: Arc<Mutex<UnixStream>>, request: Request) -> Me
                             return Message::Reconnect;
                         }
                         _ => {
-                    return Message::Error(socket, description);
+                            return Message::Error(socket, description);
                         }
                     }
                 }
@@ -1026,7 +1026,12 @@ impl cosmic::Application for App {
             if let Some((power_icon, power_percent)) = &self.power_info_opt {
                 status_row = status_row.push(iced::widget::row![
                     widget::icon::from_name(power_icon.clone()),
-                    widget::text(format!("{:.0}%", power_percent)),
+                    widget::text(if power_percent == &0.0 {
+                        format!("System is running from the wall or the battery")
+                    } else {
+                        widget::icon::from_name(power_icon.clone());
+                        format!("{:.0}%", power_percent)
+                    }),
                 ]);
             }
 

--- a/src/locker.rs
+++ b/src/locker.rs
@@ -595,9 +595,16 @@ impl cosmic::Application for App {
 
             if let Some((power_icon, power_percent)) = &self.power_info_opt {
                 status_row = status_row.push(iced::widget::row![
-                    widget::icon::from_name(power_icon.clone()),
-                    widget::text(format!("{:.0}%", power_percent)),
+                    widget::text(if power_percent == &0.0 {
+                        format!("System is running from the wall or the battery")
+                    } else {
+                        widget::icon::from_name(power_icon.clone());
+                        format!("{:.0}%", power_percent)
+                    }),
                 ]);
+            }
+            if self.power_info_opt.is_none() {
+              widget::text("System is running straight from wall");  
             }
 
             //TODO: implement these buttons

--- a/src/locker.rs
+++ b/src/locker.rs
@@ -596,7 +596,7 @@ impl cosmic::Application for App {
             if let Some((power_icon, power_percent)) = &self.power_info_opt {
                 status_row =
                     status_row.push(iced::widget::row![widget::text(if power_percent == &0.0 {
-                        format!("System is running from the wall or the battery")
+                        format!("")
                     } else {
                         widget::icon::from_name(power_icon.clone());
                         format!("{:.0}%", power_percent)

--- a/src/locker.rs
+++ b/src/locker.rs
@@ -594,17 +594,16 @@ impl cosmic::Application for App {
             }
 
             if let Some((power_icon, power_percent)) = &self.power_info_opt {
-                status_row = status_row.push(iced::widget::row![
-                    widget::text(if power_percent == &0.0 {
+                status_row =
+                    status_row.push(iced::widget::row![widget::text(if power_percent == &0.0 {
                         format!("System is running from the wall or the battery")
                     } else {
                         widget::icon::from_name(power_icon.clone());
                         format!("{:.0}%", power_percent)
-                    }),
-                ]);
+                    }),]);
             }
             if self.power_info_opt.is_none() {
-              widget::text("System is running straight from wall");  
+                widget::text("System is running straight from wall");
             }
 
             //TODO: implement these buttons


### PR DESCRIPTION
This PR adds an indication of battery missing, since current version is just displaying 0% on battery, even though I'm running the greeter on a desktop PC. This PR is thoroughly tested and causes no issues when running.