### PR TITLE
fix: exit after logind subscription error

### DIFF
--- a/src/logind.rs
+++ b/src/logind.rs
@@ -59,10 +59,7 @@ pub fn subscription() -> Subscription<Message> {
                 }
             }
 
-            //TODO: should we retry on error?
-            loop {
-                time::sleep(time::Duration::new(60, 0)).await;
-            }
+            std::process::exit(1);
         },
     )
 }


### PR DESCRIPTION
After cosmic-greeter restarts, it seems to successfully get the session path, but without exiting, there didn't seem to be a way to retry successfully. This could probably be looked more into in the future, but for now it fixes #72 