### PR TITLE
Hide battery status on devices without a battery

### DIFF
--- a/src/upower.rs
+++ b/src/upower.rs
@@ -46,7 +46,7 @@ pub async fn handler(msg_tx: &mut mpsc::Sender<Option<(String, f64)>>) -> Result
 
         if let Ok(percent) = dev.percentage().await {
             if let Ok(icon_name) = dev.icon_name().await {
-                if !icon_name.is_empty() {
+                if !icon_name.is_empty() && !icon_name.eq("battery-missing-symbolic") {
                     info_opt = Some((icon_name, percent));
                 }
             }


### PR DESCRIPTION
Fixes: #76 

When running the greeter on a PC or any device that does not have a battery, it makes more sense to hide the symbol and charge percentage. The icon 'battery-missing-symbolic' is set as the icon name in this case, so I hid tested for that and hid it. I have already tested it on hardware and it performs as expected.