### PR TITLE
Localize date strings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -699,6 +699,7 @@ dependencies = [
  "iana-time-zone",
  "js-sys",
  "num-traits",
+ "pure-rust-locales",
  "wasm-bindgen",
  "windows-targets 0.52.6",
 ]
@@ -3751,6 +3752,12 @@ name = "profiling"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43d84d1d7a6ac92673717f9f6d1518374ef257669c24ebc5ac25d5033828be58"
+
+[[package]]
+name = "pure-rust-locales"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1190fd18ae6ce9e137184f207593877e70f39b015040156b1e05081cdfe3733a"
 
 [[package]]
 name = "pwd"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-chrono = "0.4.38"
+chrono = { version = "0.4", features = ["unstable-locales"] }
 cosmic-bg-config.workspace = true
 cosmic-comp-config.workspace = true
 cosmic-config = { workspace = true, features = ["calloop", "macro"] }

--- a/src/greeter.rs
+++ b/src/greeter.rs
@@ -912,14 +912,13 @@ impl cosmic::Application for App {
                 let mut column = widget::column::with_capacity(2).padding(16.0).spacing(12.0);
 
                 let dt = chrono::Local::now();
+                let locale = *crate::localize::LANGUAGE_CHRONO;
 
-                //TODO: localized format
-                let date = dt.format("%A, %B %-d");
+                let date = dt.format_localized("%A, %B %-d", locale);
                 column = column
                     .push(widget::text::title2(format!("{}", date)).style(style::Text::Accent));
 
-                //TODO: localized format
-                let time = dt.format("%R");
+                let time = dt.format_localized("%R", locale);
                 column = column.push(
                     widget::text(format!("{}", time))
                         .size(112.0)

--- a/src/localize.rs
+++ b/src/localize.rs
@@ -1,6 +1,9 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
-use std::sync::OnceLock;
+use std::{
+    str::FromStr,
+    sync::{LazyLock, OnceLock},
+};
 
 use i18n_embed::{
     fluent::{fluent_language_loader, FluentLanguageLoader},
@@ -13,6 +16,19 @@ use rust_embed::RustEmbed;
 struct Localizations;
 
 pub static LANGUAGE_LOADER: OnceLock<FluentLanguageLoader> = OnceLock::new();
+pub static LANGUAGE_CHRONO: LazyLock<chrono::Locale> = LazyLock::new(|| {
+    std::env::var("LC_TIME")
+        .ok()
+        .or_else(|| std::env::var("LANG").ok())
+        .and_then(|locale_full| {
+            // Split LANG because it may be set to a locale such as en_US.UTF8
+            locale_full
+                .split('.')
+                .next()
+                .and_then(|locale| chrono::Locale::from_str(locale).ok())
+        })
+        .unwrap_or(chrono::Locale::en_US)
+});
 
 #[macro_export]
 macro_rules! fl {

--- a/src/locker.rs
+++ b/src/locker.rs
@@ -564,14 +564,13 @@ impl cosmic::Application for App {
                 let mut column = widget::column::with_capacity(2).padding(16.0);
 
                 let dt = chrono::Local::now();
+                let locale = *crate::localize::LANGUAGE_CHRONO;
 
-                //TODO: localized format
-                let date = dt.format("%A, %B %-d");
+                let date = dt.format_localized("%A, %B %-d", locale);
                 column = column
                     .push(widget::text::title2(format!("{}", date)).style(style::Text::Accent));
 
-                //TODO: localized format
-                let time = dt.format("%R");
+                let time = dt.format_localized("%R", locale);
                 column = column.push(
                     widget::text(format!("{}", time))
                         .size(112.0)


### PR DESCRIPTION
Mostly closes: #103

Analogous to my other patches that localize date strings (e.g. pop-os/cosmic-files#277).

![greeter_time](https://github.com/user-attachments/assets/ed9eab4d-4832-4bce-b6a6-caa76084df67)

The "password:" prompt is not localized in this patch because PAM should yield translated strings on its own. This needs further investigation, so I didn't change any code in relation to that issue.

[linux-pam/po/fr.po](https://github.com/linux-pam/linux-pam/blob/4d1d4f699551f395be065e60513eaf85f01b84e6/po/fr.po#L43-L45) contains the correct lines as mentioned in the issue.

```
#: libpam/pam_get_authtok.c:43
msgid "Current password: "
msgstr "Mot de passe actuel : "
```

[linux-pam/libpam/pam_get_authtok.c](https://github.com/linux-pam/linux-pam/blob/4d1d4f699551f395be065e60513eaf85f01b84e6/libpam/pam_get_authtok.c#L43) uses the translated string for "password:". So, I'm not sure why it's not working for COSMIC Greeter.