### PR TITLE
feat: initial support for online/offline status via systemd-networkd

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1017,6 +1017,7 @@ dependencies = [
  "xdg",
  "xkb-data",
  "zbus 4.4.0",
+ "zbus_systemd",
 ]
 
 [[package]]
@@ -5919,6 +5920,17 @@ dependencies = [
  "serde",
  "static_assertions",
  "zvariant 4.2.0",
+]
+
+[[package]]
+name = "zbus_systemd"
+version = "0.25600.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14a94191447de6983b8c81f6d57d759501e03e59be7970ab0dc069ac9e36f786"
+dependencies = [
+ "futures",
+ "serde",
+ "zbus 4.4.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,15 +41,17 @@ i18n-embed = { version = "0.14", features = [
 i18n-embed-fl = "0.7"
 rust-embed = "8"
 futures-util = "0.3.30"
+zbus_systemd = { version = "0.25600", features = ["network1"], optional = true }
 
 [dependencies.greetd_ipc]
 version = "0.10.3"
 features = ["tokio-codec"]
 
 [features]
-default = ["logind", "networkmanager", "upower"]
+default = ["logind", "networkmanager", "systemd", "upower"]
 logind = ["logind-zbus", "zbus"]
 networkmanager = ["cosmic-dbus-networkmanager", "zbus"]
+systemd = ["zbus_systemd", "zbus"]
 upower = ["upower_dbus", "zbus"]
 zbus = ["dep:zbus", "nix"]
 

--- a/src/greeter.rs
+++ b/src/greeter.rs
@@ -1408,16 +1408,17 @@ impl cosmic::Application for App {
 
         #[cfg(feature = "networkmanager")]
         {
-            subscriptions.push(
-                crate::networkmanager::subscription()
-                    .map(|icon_opt| Message::NetworkIcon(icon_opt)),
-            );
+            subscriptions.push(crate::networkmanager::subscription().map(Message::NetworkIcon));
+        }
+
+        #[cfg(feature = "systemd")]
+        {
+            subscriptions.push(crate::systemd::subscription().map(Message::NetworkIcon));
         }
 
         #[cfg(feature = "upower")]
         {
-            subscriptions
-                .push(crate::upower::subscription().map(|info_opt| Message::PowerInfo(info_opt)));
+            subscriptions.push(crate::upower::subscription().map(Message::PowerInfo));
         }
 
         Subscription::batch(subscriptions)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,5 +13,8 @@ mod logind;
 #[cfg(feature = "networkmanager")]
 mod networkmanager;
 
+#[cfg(feature = "systemd")]
+mod systemd;
+
 #[cfg(feature = "upower")]
 mod upower;

--- a/src/locker.rs
+++ b/src/locker.rs
@@ -827,16 +827,17 @@ impl cosmic::Application for App {
 
         #[cfg(feature = "networkmanager")]
         {
-            subscriptions.push(
-                crate::networkmanager::subscription()
-                    .map(|icon_opt| Message::NetworkIcon(icon_opt)),
-            );
+            subscriptions.push(crate::networkmanager::subscription().map(Message::NetworkIcon));
+        }
+
+        #[cfg(feature = "systemd")]
+        {
+            subscriptions.push(crate::systemd::subscription().map(Message::NetworkIcon));
         }
 
         #[cfg(feature = "upower")]
         {
-            subscriptions
-                .push(crate::upower::subscription().map(|info_opt| Message::PowerInfo(info_opt)));
+            subscriptions.push(crate::upower::subscription().map(Message::PowerInfo));
         }
 
         Subscription::batch(subscriptions)

--- a/src/logind.rs
+++ b/src/logind.rs
@@ -7,7 +7,6 @@ use logind_zbus::{
     session::SessionProxy,
 };
 use std::{any::TypeId, error::Error, os::fd::OwnedFd, process, sync::Arc};
-use tokio::time;
 use zbus::Connection;
 
 use crate::locker::Message;

--- a/src/systemd.rs
+++ b/src/systemd.rs
@@ -1,0 +1,62 @@
+use std::any::TypeId;
+
+use cosmic::iced::{
+    futures::{channel::mpsc, SinkExt, StreamExt},
+    subscription, Subscription,
+};
+use tokio::time;
+use zbus::{Connection, Result};
+use zbus_systemd::network1::ManagerProxy;
+
+use crate::networkmanager::NetworkIcon;
+
+pub fn subscription() -> Subscription<Option<&'static str>> {
+    struct NetworkSubscription;
+
+    subscription::channel(
+        TypeId::of::<NetworkSubscription>(),
+        16,
+        |mut msg_tx| async move {
+            match handler(&mut msg_tx).await {
+                Ok(()) => {}
+                Err(err) => {
+                    log::warn!("systemd-networkd error: {}", err);
+                    //TODO: send error
+                }
+            }
+
+            // If reading network status failed, clear network icon
+            msg_tx.send(None).await.unwrap();
+
+            //TODO: should we retry on error?
+            loop {
+                time::sleep(time::Duration::new(60, 0)).await;
+            }
+        },
+    )
+}
+
+//TODO: use never type?
+pub async fn handler(msg_tx: &mut mpsc::Sender<Option<&'static str>>) -> Result<()> {
+    let zbus = Connection::system().await?;
+    let mp = ManagerProxy::new(&zbus).await?;
+
+    let mut online_state_changed = mp.receive_online_state_changed().await;
+    loop {
+        let icon = match mp.online_state().await.unwrap_or_default().as_str() {
+            // TODO: traverse systemd-networkd's links/networks to determine wireless-versus-wired
+            // "partial" mean some links are online, let's assume this is good enough
+            // see: https://www.freedesktop.org/software/systemd/man/latest/networkctl.html
+            "online" | "partial" => NetworkIcon::Wired,
+            _ => NetworkIcon::None,
+        };
+
+        msg_tx.send(Some(icon.name())).await.unwrap();
+
+        // Waits until active connections have changed and at least one second has passed
+        tokio::join!(
+            online_state_changed.next(),
+            time::sleep(time::Duration::from_secs(3))
+        );
+    }
+}


### PR DESCRIPTION
- I run COSMIC on Arch Linux without network-manager with wpa_supplicant, instead preferring to use systemd-networkd with iwd
- `cosmic-greeter` currently shows a network indicator using information retrieved from network-manager (via D-Bus)
- this PR adds an optional dependency on the https://crates.io/crates/zbus_systemd crate which is maintained by some of the zbus folks
- this PR uses this crate to listen for signals from the systemd-networkd D-Bus service and otherwise interrogate it to determine the online/offline status, to feed the same network indicator that would otherwise be populated by the data from network-manager
- I have not tested this on a system that has both network-manager and systemd-networkd in an operational state, although I believe this would be aberrant and at worst would (as far as this PR goes) result in a few extra D-Bus calls and the potential loss of wireless-versus-wired information in the network indicator (because this PR doesn't yet offer that)
- I believe this PR offers enough value to be merge-worthy at this stage, but I do intend to follow-up with the missing wireless-versus-wired functionality (and later apply this same work to cosmic-applets)