### PR TITLE
Fix race condition when getting login session

### DIFF
--- a/src/logind.rs
+++ b/src/logind.rs
@@ -6,7 +6,7 @@ use logind_zbus::{
     manager::{InhibitType, ManagerProxy},
     session::SessionProxy,
 };
-use std::{any::TypeId, error::Error, os::fd::OwnedFd, process, sync::Arc};
+use std::{any::TypeId, error::Error, os::fd::OwnedFd, sync::Arc};
 use tokio::time;
 use zbus::Connection;
 
@@ -68,7 +68,7 @@ pub fn subscription() -> Subscription<Message> {
 pub async fn handler(msg_tx: &mut mpsc::Sender<Message>) -> Result<(), Box<dyn Error>> {
     let connection = Connection::system().await?;
     let manager = ManagerProxy::new(&connection).await?;
-    let session_path = manager.get_session_by_PID(process::id()).await?;
+    let session_path = manager.get_session_by_PID(std::os::unix::process::parent_id()).await?;
     let session = SessionProxy::builder(&connection)
         .path(&session_path)?
         .build()


### PR DESCRIPTION
If `org.freedesktop.login1.Manager.GetSessionByPID` is called after cosmic-session puts cosmic-greeter in a new systemd scope, it will no longer find the login session as it would have been removed out of the login session scope

Most of the time, cosmic-greeter gets to that call before the scope is changed, but sometimes (particularly on slower systems or virtual machines) this race can be lost and lead to cosmic-greeter failing to start and preventing lockscreen from working

This PR solves that race condition by always checking the parent PID instead (which would be cosmic-session which is always present in the login session scope), and all POSIX-y systems should support using parent PID

An alternative would be to pass the session path down from cosmic-session to cosmic-greeter, but @Drakulix also mentioned in private that y'all may end up redoing systemd desktop services management in the future, so this solution should likely be adequate for now