### PR TITLE
Set full_name_opt to None when GECOS data is empty

### DIFF
--- a/daemon/src/main.rs
+++ b/daemon/src/main.rs
@@ -109,6 +109,7 @@ impl GreeterProxy {
                 full_name_opt: user
                     .gecos
                     .as_ref()
+                    .filter(|s| !s.is_empty())
                     .map(|gecos| gecos.split(',').next().unwrap_or_default().to_string()),
                 icon_opt,
                 theme_opt: None,

--- a/src/greeter.rs
+++ b/src/greeter.rs
@@ -105,6 +105,7 @@ fn user_data_fallback() -> Vec<UserData> {
                     name: user.name,
                     full_name_opt: user
                         .gecos
+                        .filter(|s| !s.is_empty())
                         .map(|gecos| gecos.split(',').next().unwrap_or_default().to_string()),
                     icon_opt,
                     theme_opt: None,

--- a/src/locker.rs
+++ b/src/locker.rs
@@ -642,9 +642,9 @@ impl cosmic::Application for App {
                 }
                 None => {}
             }
-            match &self.flags.current_user.gecos {
+            match self.flags.current_user.gecos.as_ref().filter(|s| !s.is_empty()) {
                 Some(gecos) => {
-                    let full_name = gecos.split(",").next().unwrap_or("");
+                    let full_name = gecos.split(",").next().unwrap_or_default();
                     column = column.push(
                         widget::container(widget::text::title4(full_name))
                             .width(Length::Fill)


### PR DESCRIPTION
Since `getpwnam` returns an empty string rather than `NULL` in `pw_gecos` when GECOS field is empty in `/etc/passwd`, `pwd::Passwd::gecos` is generally `Some("")` rather than `None` when GECOS data is absent. Currently cosmic-greeter only conditions username fallback for the user list based on `UserData::full_name_opt` being `None`, and given it is almost never `None` (except in some more esoteric NSS setups) the user list appears to be empty when no GECOS data exists

This PR makes `UserData::full_name_opt` be set to `None` rather than `Some("")` when `getpwnam().pw_gecos` is an empty string, and therefore this fixes the expected behavior that `UserData::full_name_opt` can be conditinioned on being `None` for absent GECOS data

Fixes lilyinstarlight/nixos-cosmic#285