### PR TITLE
Suggest libpam-fprintd

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -27,6 +27,7 @@ Depends:
     dbus,
     ${misc:Depends},
     ${shlibs:Depends}
+Suggests: libpam-fprintd
 Provides: x-display-manager
 Description: Cosmic Greeter
 


### PR DESCRIPTION
`fprintd` was previously recommended by `ubuntu-desktop` (which is no longer part of Pop!_OS) and suggested by gdm3 (which was part of 22.04). This adds it as a suggests to `cosmic-greeter` to match `gdm3`.

While fingerprint support is not explicitly a goal for Epoch 1, several issues in this repo suggest the basic functionality does work and some people are using fingerprint readers successfully.

Ref: https://github.com/pop-os/upgrade/pull/330 