### PR TITLE
Recover previous locked state

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -996,6 +996,7 @@ dependencies = [
  "cosmic-dbus-networkmanager",
  "cosmic-greeter-config",
  "cosmic-greeter-daemon",
+ "dirs",
  "env_logger",
  "freedesktop_entry_parser",
  "futures-util",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ cosmic-comp-config.workspace = true
 cosmic-config = { workspace = true, features = ["calloop", "macro"] }
 cosmic-greeter-config.workspace = true
 cosmic-greeter-daemon = { path = "daemon" }
+dirs = "5"
 env_logger.workspace = true
 freedesktop_entry_parser = "1.3.0"
 libcosmic = { workspace = true, features = ["tokio", "wayland"] }

--- a/src/logind.rs
+++ b/src/logind.rs
@@ -7,7 +7,6 @@ use logind_zbus::{
     session::SessionProxy,
 };
 use std::{any::TypeId, error::Error, os::fd::OwnedFd, sync::Arc};
-use tokio::time;
 use zbus::Connection;
 
 use crate::locker::Message;
@@ -68,7 +67,9 @@ pub fn subscription() -> Subscription<Message> {
 pub async fn handler(msg_tx: &mut mpsc::Sender<Message>) -> Result<(), Box<dyn Error>> {
     let connection = Connection::system().await?;
     let manager = ManagerProxy::new(&connection).await?;
-    let session_path = manager.get_session_by_PID(std::os::unix::process::parent_id()).await?;
+    let session_path = manager
+        .get_session_by_PID(std::os::unix::process::parent_id())
+        .await?;
     let session = SessionProxy::builder(&connection)
         .path(&session_path)?
         .build()


### PR DESCRIPTION
This will partially address #151 by ensuring that even a compositor crash will restore the locked state as soon as the greeter restarts.