### PR TITLE
make Dutch translations consistent with one another

### DIFF
--- a/i18n/nl/cosmic_greeter.ftl
+++ b/i18n/nl/cosmic_greeter.ftl
@@ -1,10 +1,10 @@
 cancel = Annuleren
 keyboard-layout = Toetsenbordindeling
-restart = Herstarten
-restart-now = Nu herstarten?
+restart = Opnieuw opstarten
+restart-now = Nu opnieuw opstarten?
 restart-timeout = Het systeem zal na { $seconds ->
   [one] één seconde
-  *[other] {$seconds} seconden} automatisch herstarten.
+  *[other] {$seconds} seconden} automatisch opnieuw opstarten.
 session = Sessie
 shutdown = Afsluiten
 shutdown-now = Nu afsluiten?


### PR DESCRIPTION
Trying to make translations consistent with one another

https://github.com/pop-os/cosmic-applets/pull/759/files#diff-e355b8787252d733d219751b95934952d02346ab6b16a69c1c8a870c3d9b8e5e

"Herstarten" -> "Opnieuw opstarten"
Like the translation on Windows