### PR TITLE
fix: XDG_SESSION_ID may contain non-numerical characters

### DIFF
--- a/src/locker.rs
+++ b/src/locker.rs
@@ -35,14 +35,7 @@ use wayland_client::{protocol::wl_output::WlOutput, Proxy};
 
 fn lockfile_opt() -> Option<PathBuf> {
     let runtime_dir = dirs::runtime_dir()?;
-    let session_id_str = env::var("XDG_SESSION_ID").ok()?;
-    let session_id = match session_id_str.parse::<u64>() {
-        Ok(ok) => ok,
-        Err(err) => {
-            log::warn!("failed to parse session ID {:?}: {}", session_id_str, err);
-            return None;
-        }
-    };
+    let session_id = env::var("XDG_SESSION_ID").ok()?;
     Some(runtime_dir.join(format!("cosmic-greeter-{}.lock", session_id)))
 }
 


### PR DESCRIPTION
Issue report from Mattermost:

greeter panicking after: failed to parse session ID “c1”: invalid digit found in string

![IMG_7452](https://github.com/user-attachments/assets/29cec9b2-ff89-43a8-b8f6-873762c51f4f)
