### PR TITLE
feat: respect system-configured interface font

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@
 /target/
 /vendor.tar
 /vendor/
+result*

--- a/daemon/src/lib.rs
+++ b/daemon/src/lib.rs
@@ -9,6 +9,7 @@ pub struct UserData {
     pub full_name_opt: Option<String>,
     pub icon_opt: Option<Vec<u8>>,
     pub theme_opt: Option<Theme>,
+    pub interface_font_opt: Option<String>,
     pub wallpapers_opt: Option<Vec<(String, WallpaperData)>>,
     pub xkb_config_opt: Option<XkbConfig>,
     pub clock_military_time: bool,

--- a/daemon/src/main.rs
+++ b/daemon/src/main.rs
@@ -113,6 +113,7 @@ impl GreeterProxy {
                     .map(|gecos| gecos.split(',').next().unwrap_or_default().to_string()),
                 icon_opt,
                 theme_opt: None,
+                interface_font_opt: None,
                 //TODO: should wallpapers come from a per-user call?
                 wallpapers_opt: None,
                 xkb_config_opt: None,
@@ -224,6 +225,15 @@ impl GreeterProxy {
                             "failed to create CosmicAppletTime config handler: {:?}",
                             err
                         );
+                    }
+                };
+
+                match cosmic_config::Config::new("com.system76.CosmicTk", 1) {
+                    Ok(config_handler) => {
+                        user_data.interface_font_opt = config_handler.get("interface_font").unwrap_or_default();
+                    }
+                    Err(err) => {
+                        log::error!("failed to create CosmicTk config handler: {:?}", err);
                     }
                 };
             })

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,58 @@
+{
+  "nodes": {
+    "flake-parts": {
+      "inputs": {
+        "nixpkgs-lib": "nixpkgs-lib"
+      },
+      "locked": {
+        "lastModified": 1736143030,
+        "narHash": "sha256-+hu54pAoLDEZT9pjHlqL9DNzWz0NbUn8NEAHP7PQPzU=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "b905f6fc23a9051a6e1b741e1438dbfc0634c6de",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1737717945,
+        "narHash": "sha256-ET91TMkab3PmOZnqiJQYOtSGvSTvGeHoegAv4zcTefM=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "ecd26a469ac56357fd333946a99086e992452b6a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-lib": {
+      "locked": {
+        "lastModified": 1735774519,
+        "narHash": "sha256-CewEm1o2eVAnoqb6Ml+Qi9Gg/EfNAxbRx1lANGVyoLI=",
+        "type": "tarball",
+        "url": "https://github.com/NixOS/nixpkgs/archive/e9b51731911566bbf7e4895475a87fe06961de0b.tar.gz"
+      },
+      "original": {
+        "type": "tarball",
+        "url": "https://github.com/NixOS/nixpkgs/archive/e9b51731911566bbf7e4895475a87fe06961de0b.tar.gz"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-parts": "flake-parts",
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,34 @@
+{
+  inputs = {
+    flake-parts.url = "github:hercules-ci/flake-parts";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+  };
+
+  outputs =
+    inputs:
+    inputs.flake-parts.lib.mkFlake { inherit inputs; } {
+      systems = [
+        "aarch64-linux"
+        "x86_64-linux"
+      ];
+
+      perSystem =
+        { pkgs, self', ... }:
+        {
+          devShells.default = pkgs.mkShell {
+            nativeBuildInputs = with pkgs; [
+              cargo
+              clippy
+              rustc
+              rustfmt
+            ];
+
+            strictDeps = true;
+          };
+          packages = {
+            default = self'.packages.cosmic-greeter;
+            cosmic-greeter = pkgs.callPackage ./package.nix { };
+          };
+        };
+    };
+}

--- a/package.nix
+++ b/package.nix
@@ -1,0 +1,113 @@
+# Based on lilyinstarlight's work on:
+# https://github.com/lilyinstarlight/nixos-cosmic/blob/main/pkgs/cosmic-greeter/package.nix
+{
+  lib,
+  rustPlatform,
+  cmake,
+  coreutils,
+  just,
+  libinput,
+  linux-pam,
+  stdenv,
+  udev,
+  xkeyboard_config,
+  wayland,
+  vulkan-loader,
+  xorg,
+  libGL,
+  libxkbcommon,
+  makeBinaryWrapper,
+  pkg-config,
+  cosmic-icons,
+}:
+rustPlatform.buildRustPackage {
+  pname = "cosmic-greeter";
+  version = "1.0.0-alpha.5.1";
+
+  src = lib.fileset.toSource {
+    root = ./.;
+    fileset = lib.fileset.difference ./. (
+      lib.fileset.unions [
+        (lib.fileset.maybeMissing ./result)
+        (lib.fileset.maybeMissing ./target)
+        (lib.fileset.maybeMissing ./.git)
+        (lib.fileset.fileFilter (
+          file:
+          builtins.elem file.name [
+            "flake.nix"
+            "flake.lock"
+            "LICENSE"
+            "README.md"
+            ".gitignore"
+            ".gitattributes"
+            "package.nix"
+          ]
+        ) ./.)
+      ]
+    );
+  };
+
+  nativeBuildInputs = [
+    cmake
+    just
+    makeBinaryWrapper
+    pkg-config
+    rustPlatform.bindgenHook
+  ];
+
+  buildInputs = [
+    libinput
+    linux-pam
+    udev
+    wayland
+    vulkan-loader
+    xorg.libX11
+    xorg.libXcursor
+    xorg.libXi
+    xorg.libxcb
+    libGL
+    libxkbcommon
+  ];
+
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-nmkM/Jm2P5ftZFfzX+O1Fe6eobRbgBkajZsbyI67Zfw=";
+  cargoBuildFlags = [ "--all" ];
+
+  dontUseJustBuild = true;
+  dontUseJustCheck = true;
+
+  justFlags = [
+    "--set"
+    "prefix"
+    (placeholder "out")
+    "--set"
+    "bin-src"
+    "target/${stdenv.hostPlatform.rust.cargoShortTarget}/release/cosmic-greeter"
+    "--set"
+    "daemon-src"
+    "target/${stdenv.hostPlatform.rust.cargoShortTarget}/release/cosmic-greeter-daemon"
+  ];
+
+  postPatch = ''
+    substituteInPlace src/greeter.rs --replace-fail '/usr/bin/env' '${lib.getExe' coreutils "env"}'
+  '';
+
+  postInstall = ''
+    wrapProgram "$out/bin/cosmic-greeter" \
+      --set-default X11_BASE_RULES_XML "${xkeyboard_config}/share/X11/xkb/rules/base.xml" \
+      --set-default X11_EXTRA_RULES_XML "${xkeyboard_config}/share/X11/xkb/rules/base.extras.xml" \
+      --suffix XDG_DATA_DIRS : "${cosmic-icons}/share" \
+      --prefix LD_LIBRARY_PATH : "${
+        lib.makeLibraryPath [
+          xorg.libX11
+          xorg.libXcursor
+          xorg.libXi
+          xorg.libxcb
+          libGL
+          libxkbcommon
+          wayland
+          vulkan-loader
+        ]
+      }"
+  '';
+}


### PR DESCRIPTION
Closes #156 

- Add interface_font_opt field to UserData struct
- Read interface font from CosmicTk config
- Integrate interface font with cosmic::iced::Font system
- Initialize interface_font_opt in fallback data with None

The greeter now respects the interface font configured in COSMIC Settings, providing a consistent font experience across the desktop environment.

NOTE: I didn't test this yet, but it should work