### PR TITLE
CLI with Lexopt

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1159,6 +1159,7 @@ dependencies = [
  "greetd_ipc",
  "i18n-embed",
  "i18n-embed-fl",
+ "lexopt",
  "libcosmic",
  "log",
  "logind-zbus",
@@ -3186,6 +3187,12 @@ name = "lazycell"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
+
+[[package]]
+name = "lexopt"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baff4b617f7df3d896f97fe922b64817f6cd9a756bb81d40f8883f2f66dcb401"
 
 [[package]]
 name = "libc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,8 @@ nix = { workspace = true, optional = true }
 upower_dbus = { git = "https://github.com/pop-os/dbus-settings-bindings", rev = "badfc6a", optional = true }
 # Required for some features
 zbus = { workspace = true, optional = true }
+# CLI arguments
+lexopt = "0.3.0"
 # Internationalization
 i18n-embed = { version = "0.14", features = [
     "fluent-system",

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,7 +3,36 @@
 
 use cosmic_greeter::{greeter, locker};
 
+use lexopt::{Parser, Arg};
+const APP_VERSION: &str = env!("CARGO_PKG_VERSION");
+
+fn print_help() {
+    println!("Usage: cosmic-greeter");
+    println!("\nCOSMIC Greeter");
+    println!("A login and lock screen manager designed for the COSMIC desktop environment. \nFor more information, visit the GitHub repository at https://github.com/pop-os/cosmic-greeter.");
+    println!("\nOptions:");
+    println!("  --help     Show this message");
+    println!("  --version  Show the version of cosmic-greeter");
+}
+
 fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let mut parser = Parser::from_env();
+
+    // Parse the arguments
+    while let Some(arg) = parser.next()? {
+        match arg {
+            Arg::Long("help") => {
+                print_help();
+                return Ok(());
+            }
+            Arg::Long("version") => {
+                println!("cosmic-greeter {}", APP_VERSION);
+                return Ok(());
+            }
+            _ => {}
+        }
+    }
+	
     match pwd::Passwd::current_user() {
         Some(current_user) => match current_user.name.as_str() {
             "cosmic-greeter" => greeter::main(),
@@ -11,4 +40,5 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         },
         _ => Err("failed to determine current user".into()),
     }
+
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,12 +7,17 @@ use lexopt::{Parser, Arg};
 const APP_VERSION: &str = env!("CARGO_PKG_VERSION");
 
 fn print_help() {
-    println!("Usage: cosmic-greeter");
-    println!("\nCOSMIC Greeter");
-    println!("A login and lock screen manager designed for the COSMIC desktop environment. \nFor more information, visit the GitHub repository at https://github.com/pop-os/cosmic-greeter.");
-    println!("\nOptions:");
-    println!("  --help     Show this message");
-    println!("  --version  Show the version of cosmic-greeter");
+    println!(
+        r#"
+COSMIC Greeter
+A login and lock screen manager designed for the COSMIC desktop environment.
+
+Project home page: https://github.com/pop-os/cosmic-greeter
+
+Options:
+  --help     Show this message
+  --version  Show the version of cosmic-greeter"#
+    );
 }
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {


### PR DESCRIPTION
 I've added the support for --version and --help arguments, this timewith Lexopt
Very useful to get some informations

The stripped binary is 21020 KB.

Hopefully in the futur Cargo.toml will be updated on a regular basis
