### PR TITLE
Cli with Lexopt

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1159,6 +1159,7 @@ dependencies = [
  "greetd_ipc",
  "i18n-embed",
  "i18n-embed-fl",
+ "lexopt",
  "libcosmic",
  "log",
  "logind-zbus",
@@ -3186,6 +3187,12 @@ name = "lazycell"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
+
+[[package]]
+name = "lexopt"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baff4b617f7df3d896f97fe922b64817f6cd9a756bb81d40f8883f2f66dcb401"
 
 [[package]]
 name = "libc"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -196,6 +196,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.97"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcfed56ad506cb2c684a14971b8861fdc3baaaae314b9e5f9bb532cbe3ba7a4f"
+
+[[package]]
 name = "apply"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1171,6 +1177,7 @@ dependencies = [
  "shlex",
  "tokio",
  "upower_dbus",
+ "vergen",
  "wayland-client",
  "xdg",
  "xkb-data",
@@ -3697,6 +3704,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_threads"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "objc"
 version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5264,7 +5280,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d9c75b47bdff86fa3334a3db91356b8d7d86a9b839dab7d0bdc5c3d3a077618"
 dependencies = [
  "deranged",
+ "itoa",
+ "libc",
  "num-conv",
+ "num_threads",
  "powerfmt",
  "serde",
  "time-core",
@@ -5668,6 +5687,18 @@ name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "vergen"
+version = "8.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2990d9ea5967266ea0ccf413a4aa5c42a93dbcfda9cb49a97de6931726b12566"
+dependencies = [
+ "anyhow",
+ "cfg-if",
+ "rustversion",
+ "time",
+]
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,9 @@ name = "cosmic-greeter"
 version = "0.1.0"
 edition = "2024"
 
+[build-dependencies]
+vergen = { version = "8", features = ["git", "gitcl"] }
+
 [dependencies]
 chrono = { version = "0.4", features = ["unstable-locales"] }
 cosmic-bg-config.workspace = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,8 @@ nix = { workspace = true, optional = true }
 upower_dbus = { git = "https://github.com/pop-os/dbus-settings-bindings", rev = "badfc6a", optional = true }
 # Required for some features
 zbus = { workspace = true, optional = true }
+# CLI arguments
+lexopt = "0.3.0"
 # Internationalization
 i18n-embed = { version = "0.14", features = [
     "fluent-system",

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,9 @@
+use vergen::EmitBuilder;
+
+fn main() {
+    EmitBuilder::builder()
+        .git_sha(true)
+        .emit()
+        .unwrap();
+}
+

--- a/build.rs
+++ b/build.rs
@@ -1,9 +1,5 @@
 use vergen::EmitBuilder;
 
 fn main() {
-    EmitBuilder::builder()
-        .git_sha(true)
-        .emit()
-        .unwrap();
+    EmitBuilder::builder().git_sha(true).emit().unwrap();
 }
-

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,12 +4,10 @@
 use cosmic_greeter::{greeter, locker};
 
 use lexopt::{Parser, Arg};
-const APP_VERSION: &str = env!("CARGO_PKG_VERSION");
 
 fn print_help() {
     println!(
-        r#"
-COSMIC Greeter
+        r#"COSMIC Greeter
 A login and lock screen manager designed for the COSMIC desktop environment.
 
 Project home page: https://github.com/pop-os/cosmic-greeter
@@ -26,12 +24,15 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Parse the arguments
     while let Some(arg) = parser.next()? {
         match arg {
-            Arg::Long("help") => {
+            Arg::Short('h') | Arg::Long("help") => {
                 print_help();
                 return Ok(());
             }
-            Arg::Long("version") => {
-                println!("cosmic-greeter {}", APP_VERSION);
+            Arg::Short('v') | Arg::Long("version") => {
+                println!("cosmic-term {} (git commit {})",
+                    env!("CARGO_PKG_VERSION"),
+                    env!("VERGEN_GIT_SHA")
+                );
                 return Ok(());
             }
             _ => {}

--- a/src/main.rs
+++ b/src/main.rs
@@ -29,7 +29,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 return Ok(());
             }
             Arg::Short('v') | Arg::Long("version") => {
-                println!("cosmic-term {} (git commit {})",
+                println!("cosmic-greeter {} (git commit {})",
                     env!("CARGO_PKG_VERSION"),
                     env!("VERGEN_GIT_SHA")
                 );

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,7 +3,36 @@
 
 use cosmic_greeter::{greeter, locker};
 
+use lexopt::{Parser, Arg};
+const APP_VERSION: &str = env!("CARGO_PKG_VERSION");
+
+fn print_help() {
+    println!("Usage: cosmic-greeter");
+    println!("\nCOSMIC Greeter");
+    println!("A login and lock screen manager designed for the COSMIC desktop environment. \nFor more information, visit the GitHub repository at https://github.com/pop-os/cosmic-greeter.");
+    println!("\nOptions:");
+    println!("  --help     Show this message");
+    println!("  --version  Show the version of cosmic-greeter");
+}
+
 fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let mut parser = Parser::from_env();
+
+    // Parse the arguments
+    while let Some(arg) = parser.next()? {
+        match arg {
+            Arg::Long("help") => {
+                print_help();
+                return Ok(());
+            }
+            Arg::Long("version") => {
+                println!("cosmic-greeter {}", APP_VERSION);
+                return Ok(());
+            }
+            _ => {}
+        }
+    }
+	
     match pwd::Passwd::current_user() {
         Some(current_user) => match current_user.name.as_str() {
             "cosmic-greeter" => greeter::main(),
@@ -11,4 +40,5 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         },
         _ => Err("failed to determine current user".into()),
     }
+
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,12 +7,17 @@ use lexopt::{Parser, Arg};
 const APP_VERSION: &str = env!("CARGO_PKG_VERSION");
 
 fn print_help() {
-    println!("Usage: cosmic-greeter");
-    println!("\nCOSMIC Greeter");
-    println!("A login and lock screen manager designed for the COSMIC desktop environment. \nFor more information, visit the GitHub repository at https://github.com/pop-os/cosmic-greeter.");
-    println!("\nOptions:");
-    println!("  --help     Show this message");
-    println!("  --version  Show the version of cosmic-greeter");
+    println!(
+        r#"
+COSMIC Greeter
+A login and lock screen manager designed for the COSMIC desktop environment.
+
+Project home page: https://github.com/pop-os/cosmic-greeter
+
+Options:
+  --help     Show this message
+  --version  Show the version of cosmic-greeter"#
+    );
 }
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,20 +3,7 @@
 
 use cosmic_greeter::{greeter, locker};
 
-use lexopt::{Parser, Arg};
-
-fn print_help() {
-    println!(
-        r#"COSMIC Greeter
-A login and lock screen manager designed for the COSMIC desktop environment.
-
-Project home page: https://github.com/pop-os/cosmic-greeter
-
-Options:
-  --help     Show this message
-  --version  Show the version of cosmic-greeter"#
-    );
-}
+use lexopt::{Arg, Parser};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut parser = Parser::from_env();
@@ -25,11 +12,12 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     while let Some(arg) = parser.next()? {
         match arg {
             Arg::Short('h') | Arg::Long("help") => {
-                print_help();
+                print_help(env!("CARGO_PKG_VERSION"), env!("VERGEN_GIT_SHA"));
                 return Ok(());
             }
             Arg::Short('v') | Arg::Long("version") => {
-                println!("cosmic-greeter {} (git commit {})",
+                println!(
+                    "cosmic-greeter {} (git commit {})",
                     env!("CARGO_PKG_VERSION"),
                     env!("VERGEN_GIT_SHA")
                 );
@@ -38,7 +26,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             _ => {}
         }
     }
-	
+
     match pwd::Passwd::current_user() {
         Some(current_user) => match current_user.name.as_str() {
             "cosmic-greeter" => greeter::main(),
@@ -46,5 +34,20 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         },
         _ => Err("failed to determine current user".into()),
     }
+}
 
+fn print_help(version: &str, git_rev: &str) {
+    println!(
+        r#"cosmic-greeter {version} (git commit {git_rev})
+System76 <info@system76.com>
+
+Designed for the COSMIC™ desktop environment, cosmic-greeter is a libcosmic
+frontend for greetd which can be run inside of cosmic-comp.
+
+Project home page: https://github.com/pop-os/cosmic-greeter
+
+Options:
+  -h, --help     Show this message
+  -v, --version  Show the version of cosmic-greeter"#
+    );
 }


### PR DESCRIPTION
I've added the support for --version and --help arguments, this timewith Lexopt
Very useful to get some informations

The stripped binary is 21020 KB.

Hopefully in the futur Cargo.toml will be updated on a regular basis
