### PR TITLE
Add support for Nix develop through flakes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+/flake.lock
 /.cargo/
 /debian/*debhelper*
 /debian/cosmic-greeter.substvars

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,36 @@
+{
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+    utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, utils }:
+    utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = import nixpkgs { inherit system; };
+      in
+      {
+        devShell = with pkgs; mkShell rec {
+          nativeBuildInputs = with pkgs; [ pkg-config ];
+          buildInputs = [ 
+            cargo
+            rustc
+            rustfmt
+            pre-commit
+            rustPackages.clippy
+            libxkbcommon
+            libxkbcommon.dev
+            clang
+            udev
+            pam
+            libinput
+            llvmPackages.libclang
+          ];
+
+          RUST_SRC_PATH = rustPlatform.rustLibSrc;
+          LIBCLANG_PATH = "${llvmPackages.libclang.lib}/lib";
+          LD_LIBRARY_PATH = pkgs.lib.makeLibraryPath buildInputs;
+        };
+      }
+    );
+}


### PR DESCRIPTION
For the unfamiliar, flake.nix is vaguely similar to what a Dockerfile would be: It describes packages, dependencies, environment variables required to build the project.

This flake.nix should be all that's required for someone who wants to build this project under Nix. Although I haven't tested it myself, I believe the flake should support most system configuration as it doesn't have hard coded values, but if there was such a problem, I'd be more than happy to help and fix those as they arise.

Here's how someone would use this flake to build cosmic-greeter:

```
cd cosmic-greeter
nix develop
cargo build
```