### PR TITLE
Fix: Immediately apply keyboard layout changes in greeter

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -141,7 +141,12 @@ impl<M: From<Message> + Send + 'static> Common<M> {
             }
             if let Some(comp_config_handler) = &self.comp_config_handler {
                 match comp_config_handler.set("xkb_config", xkb_config) {
-                    Ok(()) => tracing::info!("updated cosmic-comp xkb_config"),
+                    Ok(()) => {
+                        tracing::info!("updated cosmic-comp xkb_config");
+                        if let Err(err) = comp_config_handler.reload() {
+                            tracing::error!("failed to reload cosmic-comp config: {}", err);
+                        }
+                    },
                     Err(err) => tracing::error!("failed to update cosmic-comp xkb_config: {}", err),
                 }
             }


### PR DESCRIPTION
Addressing a critical usability issue where keyboard layout changes (specifically those impacting AltGr keys) were not being immediately recognized or applied in the Cosmic Greeter login screen.

After a clean install using a non-default keyboard layout (like Portuguese - Default), users were unable to type special characters that rely on the AltGr modifier key, such as:

@ (AltGr + 2 on Portuguese keyboard)

{ or ]

€ (AltGr + E)

This prevented users from logging into newly created accounts if their password contained such characters.

Changes
The fix ensures that the Greeter's compositor immediately loads the new XKB configuration by calling:
comp_config_handler.reload() after updating the xkb_config.

This change allows the keyboard layout to take effect immediately, resolving the inability to type special characters on the login screen.

Testing Steps (as per related issue pop-os/distinst#348)
Install Pop!_OS 24.04 Beta (or a similar Cosmic Epoch environment).

During installation:

Select a language (e.g., English - United Kingdom).

Select a layout that uses AltGr (e.g., Portuguese - Default).

Create a user account with a password containing the @ character.

Reboot to the login screen.

On the Cosmic Greeter login screen, attempt to type the password (specifically the @ character using AltGr + 2).

Expected Behavior with this Fix: The special characters should now be entered correctly, allowing the user to log in successfully. 

Issue link: https://github.com/pop-os/cosmic-epoch/issues/2242