### PR TITLE
i18n(sr): Add Serbian translations

### DIFF
--- a/i18n/sr-Cyrl/cosmic_greeter.ftl
+++ b/i18n/sr-Cyrl/cosmic_greeter.ftl
@@ -1,0 +1,27 @@
+accessibility = Приступачност
+    .screen-reader = Читач екрана
+    .magnifier = Лупа
+    .high-contrast = Високи контраст
+    .invert-colors = Обрни боје
+cancel = Откажи
+caps-lock = Caps Lock је активан.
+enter-user = Унесите име...
+type-username = Корисничко име:
+keyboard-layout = Распоред тастатуре
+restart = Поновно покретање
+restart-now = Поново покренути сада?
+restart-timeout = Систем ће се аутоматски поново покренути за
+  { $seconds ->
+    [1] 1 секунду.
+    *[other] {$seconds} секунди.
+  }
+session = Сесија
+shutdown = Искључи
+shutdown-now = Искључити сада?
+shutdown-timeout = Систем ће се аутоматски искључити за
+  { $seconds ->
+    [1] 1 секунду.
+    *[other] {$seconds} секунди.
+  }
+suspend = Стање спавања
+user = Корисник

--- a/i18n/sr-Latn/cosmic_greeter.ftl
+++ b/i18n/sr-Latn/cosmic_greeter.ftl
@@ -1,0 +1,27 @@
+accessibility = Pristupačnost
+    .screen-reader = Čitač ekrana
+    .magnifier = Lupa
+    .high-contrast = Visoki kontrast
+    .invert-colors = Obrni boje
+cancel = Otkaži
+caps-lock = Caps Lock je aktivan.
+enter-user = Unesite ime...
+type-username = Korisničko ime:
+keyboard-layout = Raspored tastature
+restart = Ponovno pokretanje
+restart-now = Ponovo pokrenuti sada?
+restart-timeout = Sistem će se automatski ponovo pokrenuti za
+  { $seconds ->
+    [1] 1 sekundu.
+    *[other] {$seconds} sekunde.
+  }
+session = Sesija
+shutdown = Isključi
+shutdown-now = Isključiti sada?
+shutdown-timeout = Sistem će se automatski isključiti za
+  { $seconds ->
+    [1] 1 sekundu.
+    *[other] {$seconds} sekunde.
+  }
+suspend = Stanje spavanja
+user = Korisnik


### PR DESCRIPTION
Not sure how and when I commited a translation to Weblate with the empty file, but this removes it and adds translations for both scripts.

Not sure if it's possible, but it would potentially be nice if the scriptless localization was removed from Weblate (maybe it gets removed automatically after this?).