### PR TITLE
feat: add better error handling for dependencies not in PATH

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1260,6 +1260,7 @@ dependencies = [
  "upower_dbus",
  "vergen",
  "wayland-client",
+ "which",
  "xdg 3.0.0",
  "xkb-data",
  "zbus 5.11.0",
@@ -1821,6 +1822,12 @@ dependencies = [
  "quote",
  "syn 2.0.106",
 ]
+
+[[package]]
+name = "env_home"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f84e12ccf0a7ddc17a6c41c93326024c42920d7ee630d04950e6926645c0fe"
 
 [[package]]
 name = "equivalent"
@@ -7021,6 +7028,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "which"
+version = "8.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3fabb953106c3c8eea8306e4393700d7657561cb43122571b172bbfb7c7ba1d"
+dependencies = [
+ "env_home",
+ "rustix 1.1.2",
+ "winsafe",
+]
+
+[[package]]
 name = "widestring"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7583,6 +7601,12 @@ checksum = "21a0236b59786fed61e2a80582dd500fe61f18b5dca67a4a067d0bc9039339cf"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "winsafe"
+version = "0.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d135d17ab770252ad95e9a872d365cf3090e3be864a34ab46f48555993efc904"
 
 [[package]]
 name = "wit-bindgen"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,6 +75,7 @@ timedate-zbus = { git = "https://github.com/pop-os/dbus-settings-bindings" }
 cosmic-randr-shell = { workspace = true }
 kdl.workspace = true
 color-eyre.workspace = true
+which = "8.0.0"
 
 [dependencies.greetd_ipc]
 version = "0.10.3"

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,7 @@
 use clap_lex::RawArgs;
 use cosmic_greeter::{greeter, locker};
 use std::error::Error;
+use which::which;
 
 fn main() -> Result<(), Box<dyn Error>> {
     let raw_args = RawArgs::from_args();
@@ -23,6 +24,25 @@ fn main() -> Result<(), Box<dyn Error>> {
                     env!("VERGEN_GIT_SHA")
                 );
                 return Ok(());
+            },
+            Some("--check-deps") => {
+                let mut failed = false;
+                for cmd in [ "orca", "env", "cosmic-randr", "startx" ] {
+                    match which(cmd) {
+                        Ok(cmd_path) => {
+                            println!("Found {cmd} at: {}", cmd_path.display().to_string());
+                        },
+                        Err(err) => {
+                            println!("Could not find {cmd} in PATH: {err:?}");
+                            failed = true;
+                        }
+                    }
+                }
+                if failed {
+                    return Err("failed to find at least one dependency".into())
+                } else {
+                    return Ok(());
+                }
             }
             _ => {}
         }


### PR DESCRIPTION
This updates cosmic-greeter to use the PATH to search for binaries such as orca and coreutils env, and also logs when they could not be found rather than failing when the command is attempted to be run. It also adds a command for packagers to be able to validate that they've correctly packaged cosmic-greeter with its dependencies.

CC @HeitorAugustoLN, will require a minor change to the nixpkgs drv if merged (removing the `postPatch` and adding the deps to the PATH, and adding `cosmic-greeter --check-deps` to `checkPhase`)