### PR TITLE
change lower uid boundary

### DIFF
--- a/cosmic-greeter-config/src/user.rs
+++ b/cosmic-greeter-config/src/user.rs
@@ -15,5 +15,5 @@ pub struct UserState {
 
 // Only serialize users not system accounts
 const fn invalid_uid(uid: &NonZeroU32) -> bool {
-    uid.get() < 1000
+    uid.get() < 500
 }

--- a/daemon/src/main.rs
+++ b/daemon/src/main.rs
@@ -62,7 +62,7 @@ impl GreeterProxy {
         let users: Vec<_> = /* unsafe */ {
              pwd::Passwd::iter()
                 .filter(|user| {
-                    if user.uid < 1000 {
+                    if user.uid < 500 {
                         // Skip system accounts
                         return false;
                     }
@@ -80,7 +80,7 @@ impl GreeterProxy {
 
         let mut user_datas = Vec::new();
         for user in users {
-            if user.uid < 1000 {
+            if user.uid < 500 {
                 // Skip system accounts
                 continue;
             }

--- a/src/greeter.rs
+++ b/src/greeter.rs
@@ -96,7 +96,7 @@ fn user_data_fallback() -> Vec<UserData> {
     {
         pwd::Passwd::iter()
             .filter(|user| {
-                if user.uid < 1000 {
+                if user.uid < 500 {
                     // Skip system accounts
                     return false;
                 }


### PR DESCRIPTION
until uid limits have been made configurable (as suggested in #297) 500 should be used as lower boundary (as per [LSB](https://refspecs.linuxfoundation.org/LSB_5.0.0/LSB-Core-generic/LSB-Core-generic/uidrange.html) saying that user ids 0-499 are for system accounts).