### PR TITLE
Prevent content moving when Caps Lock or error text are shown

### DIFF
--- a/daemon/src/lib.rs
+++ b/daemon/src/lib.rs
@@ -45,7 +45,7 @@ impl UserData {
                 //TODO: do not reread duplicate paths, cache data by path?
                 BgSource::Path(path) => {
                     if !self.bg_path_data.contains_key(path) {
-                        match fs::read(&path) {
+                        match fs::read(path) {
                             Ok(bytes) => {
                                 self.bg_path_data.insert(path.clone(), bytes);
                             }

--- a/examples/server.rs
+++ b/examples/server.rs
@@ -49,15 +49,13 @@ async fn main() {
                     auth_message_type: AuthMessageType::Secret,
                     auth_message: "MOCKING:".to_string(),
                 },
-                Request::PostAuthMessageResponse { response } => {
-                    match response.as_ref().map(|x| x.as_str()) {
-                        Some("password") => Response::Success,
-                        _ => Response::Error {
-                            error_type: ErrorType::AuthError,
-                            description: "pam_authenticate: AUTH_ERR".to_string(),
-                        },
-                    }
-                }
+                Request::PostAuthMessageResponse { response } => match response.as_deref() {
+                    Some("password") => Response::Success,
+                    _ => Response::Error {
+                        error_type: ErrorType::AuthError,
+                        description: "pam_authenticate: AUTH_ERR".to_string(),
+                    },
+                },
                 Request::StartSession { .. } => Response::Success,
                 Request::CancelSession => Response::Success,
             };

--- a/src/wayland/mod.rs
+++ b/src/wayland/mod.rs
@@ -1,7 +1,6 @@
 // Copyright 2023 System76 <info@system76.com>
 // SPDX-License-Identifier: GPL-3.0-only
 
-use anyhow;
 use cctk::sctk::reexports::calloop;
 use cosmic::iced::{
     self, Subscription,


### PR DESCRIPTION
This prevents the other column items from jumping around depending on if Caps Lock is toggled or if an error is shown. Now only the error text moves depending on if Caps Lock is toggled.
Edit: Also changed the error text color to red to match `cosmic-osd`.

Not sure if it would potentially be desirable to rearrange things so that the error text also doesn't move. Putting the Caps Lock indicator at the right end of the status row on the left would make it potentially too far from the input box (and would likely need a new caps lock indicator icon), and placing it after the error seems potentially difficult since it's inside a match (and not sure if it's desirable).