### PR TITLE
Make offset of prompt from top of screen proportional

### DIFF
--- a/src/greeter.rs
+++ b/src/greeter.rs
@@ -884,7 +884,8 @@ impl App {
                 .align_x(Alignment::Center)
                 .width(Length::Fill)
         };
-        let menu = widget::container(
+        let menu = widget::container(widget::column::with_children(vec![
+            widget::Space::with_height(Length::FillPortion(1)).into(),
             widget::layer_container(
                 iced::widget::row![left_element, right_element].align_y(Alignment::Center),
             )
@@ -902,13 +903,13 @@ impl App {
                 },
             )))
             .class(cosmic::theme::Container::Background)
-            .width(Length::Fixed(800.0)),
-        )
-        .padding([32.0, 0.0, 0.0, 0.0])
+            .width(Length::Fixed(800.0))
+            .into(),
+            widget::Space::with_height(Length::FillPortion(4)).into(),
+        ]))
         .width(Length::Fill)
-        .height(Length::Shrink)
-        .align_x(Alignment::Center)
-        .align_y(Alignment::Start);
+        .height(Length::Fill)
+        .align_x(Alignment::Center);
 
         let popover = widget::popover(menu).modal(true);
         match self.dialog_page_opt {

--- a/src/locker.rs
+++ b/src/locker.rs
@@ -505,7 +505,8 @@ impl App {
                 .width(Length::Fill)
         };
 
-        widget::container(
+        widget::container(widget::column::with_children(vec![
+            widget::Space::with_height(Length::FillPortion(1)).into(),
             widget::layer_container(
                 iced::widget::row![left_element, right_element].align_y(Alignment::Center),
             )
@@ -523,13 +524,13 @@ impl App {
                 },
             )))
             .width(Length::Fill)
-            .height(Length::Shrink),
-        )
-        .padding([32.0, 0.0, 0.0, 0.0])
+            .height(Length::Shrink)
+            .into(),
+            widget::Space::with_height(Length::FillPortion(4)).into(),
+        ]))
         .width(Length::Fill)
         .height(Length::Fill)
         .align_x(Alignment::Center)
-        .align_y(Alignment::Start)
         .class(cosmic::theme::Container::Transparent)
         .into()
     }


### PR DESCRIPTION
This roughly positions it with 1/4th the space above it as below it, hopefully putting it at an ergonomic eye level. I'd appreciate some testing with different screen sizes and also screens in portrait mode. Getting some screenshots for evaluation by UX would be helpful as well. If this feels like too much space on top or bottom, the ratio can be adjusted.