### PR TITLE
toolchain: update to 1.90

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.85.1"
+channel = "1.90"
 components = ["clippy", "rustfmt"]


### PR DESCRIPTION
### Description
Same reasons as [#1863](https://github.com/pop-os/cosmic-comp/pull/1863)