### PR TITLE
fix: improve error handling to prevent softlock

### DIFF
--- a/src/greeter/ipc.rs
+++ b/src/greeter/ipc.rs
@@ -101,15 +101,16 @@ pub fn subscription() -> Subscription<Message> {
                                             )
                                             .await;
                                     }
-                                    //TODO: treat error type differently?
-                                    greetd_ipc::AuthMessageType::Info
-                                    | greetd_ipc::AuthMessageType::Error => {
+                                    greetd_ipc::AuthMessageType::Info => {
                                         _ = sender
                                             .send(
                                                 common::Message::Prompt(auth_message, false, None)
                                                     .into(),
                                             )
                                             .await;
+                                    }
+                                    greetd_ipc::AuthMessageType::Error => {
+                                        _ = sender.send(Message::Error(auth_message)).await;
                                     }
                                 },
                                 greetd_ipc::Response::Error {


### PR DESCRIPTION
- Greeter IPC `AuthMessageType::Error` are forwarded as `Message::Error` instead of `Message::Prompt`.
- Locker PAM conversation treats `error_msg` as errors via `error_message`, which are forwarded as `Message::Error` as well.

Fixes an issue introduced by https://github.com/pop-os/cosmic-greeter/pull/349:

For example, when using **_systemd-homed_**, failed authentication would previously be treated as normal prompts, causing the greeter to softlock in the "Authenticating..." state, even though authentication has already failed.
This appears to happen due to pam_systemd_home sending `PAM_ERROR_MSG` followed by `PAM_PROMPT_ECHO_OFF`, instead of the usual `PAM_AUTH_ERR` or similar.

With this patch, PAM errors reset the "Authenticating..." state, and password input is re-enabled.