### PR TITLE
feat: fallback to default wallpaper on bg state load error

### DIFF
--- a/src/locker.rs
+++ b/src/locker.rs
@@ -211,9 +211,7 @@ impl Conversation {
 
         futures::executor::block_on(async {
             self.msg_tx
-                .send(cosmic::Action::App(
-                    Message::Error(prompt.to_string()),
-                ))
+                .send(cosmic::Action::App(Message::Error(prompt.to_string())))
                 .await
         })
         .map_err(|err| {
@@ -1010,8 +1008,8 @@ impl cosmic::Application for App {
                 self.value_tx_opt = Some(value_tx);
             }
             Message::BackgroundState(bg_state) => {
-                self.flags.user_data.bg_state = bg_state;
-                self.flags.user_data.load_wallpapers_as_user();
+                self.flags.user_data.wallpapers.update_bg_state(bg_state);
+                self.flags.user_data.wallpapers.load_as_user();
                 self.common.surface_images.clear();
                 self.common.update_wallpapers(&self.flags.user_data);
             }


### PR DESCRIPTION
Background state can fail to load, resulting in a gray background. This adds a fallback to the default / fallback background defined in `cosmic-bg-config`.

I'm using `systemd-homed` w/ luks encrypted storage, so _all_ user data fails to load until I activate my home directory on first login. Background was the only thing that was noticeable and showing the default is at least better than nothing.

This was tested locally on my machine and works as intended, showing `/usr/share/backgrounds/cosmic/orion_nebula_nasa_heic0601a.jpg` as the fallback.