### PR TITLE
refactor: get the outputs config from cosmic-comp-config

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1208,14 +1208,14 @@ dependencies = [
 
 [[package]]
 name = "cosmic-comp-config"
-version = "0.1.0"
-source = "git+https://github.com/pop-os/cosmic-comp#64a9c1badfd6f9b3af3af6db2b07b3d76d6f5102"
+version = "1.0.0"
 dependencies = [
  "cosmic-config",
  "cosmic-randr-shell",
  "input",
- "ron 0.9.0",
+ "ron 0.11.0",
  "serde",
+ "slotmap",
  "tracing",
 ]
 
@@ -1280,7 +1280,7 @@ dependencies = [
  "dirs 5.0.1",
  "ini_core",
  "memmap2 0.9.8",
- "thiserror 2.0.16",
+ "thiserror 2.0.17",
  "tracing",
  "xdg 2.5.2",
 ]
@@ -1320,7 +1320,7 @@ dependencies = [
  "nix 0.30.1",
  "pam-client",
  "pwd",
- "ron 0.11.0",
+ "ron 0.12.0",
  "rust-embed",
  "shlex",
  "timedate-zbus",
@@ -1360,7 +1360,7 @@ dependencies = [
  "libc",
  "nix 0.30.1",
  "pwd",
- "ron 0.11.0",
+ "ron 0.12.0",
  "serde",
  "tokio",
  "tracing",
@@ -1387,12 +1387,11 @@ dependencies = [
 [[package]]
 name = "cosmic-randr-shell"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/cosmic-randr#bce9cdf2d447508d4e2d54a2be4fcd738ab51df5"
+source = "git+https://github.com/pop-os/cosmic-randr#741089cf5e3aa7d5e48042101c1d4cc813b13637"
 dependencies = [
  "kdl",
  "slotmap",
- "thiserror 2.0.16",
- "tokio",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
@@ -1442,7 +1441,7 @@ dependencies = [
  "num-derive",
  "num-traits",
  "smithay-client-toolkit 0.20.0",
- "thiserror 2.0.16",
+ "thiserror 2.0.17",
  "tokio",
  "tokio-stream",
  "tracing",
@@ -1484,7 +1483,7 @@ dependencies = [
  "ron 0.11.0",
  "serde",
  "serde_json",
- "thiserror 2.0.16",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
@@ -2141,7 +2140,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "54f0d287c53ffd184d04d8677f590f4ac5379785529e5e08b1c8083acdd5c198"
 dependencies = [
  "memchr",
- "thiserror 2.0.16",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
@@ -2247,7 +2246,7 @@ dependencies = [
  "gettext-rs",
  "log",
  "memchr",
- "thiserror 2.0.16",
+ "thiserror 2.0.17",
  "unicase",
  "xdg 2.5.2",
 ]
@@ -3487,9 +3486,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.11.3"
+version = "2.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92119844f513ffa41556430369ab02c295a3578af21cf945caa3e9e0c2481ac3"
+checksum = "4b0f83760fb341a774ed326568e19f5a863af4a952def8c39f9ab92fd95b88e5"
 dependencies = [
  "equivalent",
  "hashbrown 0.15.5",
@@ -3833,7 +3832,7 @@ dependencies = [
  "shlex",
  "slotmap",
  "taffy",
- "thiserror 2.0.16",
+ "thiserror 2.0.17",
  "tokio",
  "tracing",
  "unicode-segmentation",
@@ -4195,7 +4194,7 @@ dependencies = [
  "cfg_aliases 0.1.1",
  "codespan-reporting",
  "hexf-parse",
- "indexmap 2.11.3",
+ "indexmap 2.11.4",
  "log",
  "rustc-hash 1.1.0",
  "spirv",
@@ -5496,7 +5495,7 @@ checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
 dependencies = [
  "getrandom 0.2.16",
  "libredox",
- "thiserror 2.0.16",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
@@ -5605,9 +5604,9 @@ dependencies = [
 
 [[package]]
 name = "ron"
-version = "0.9.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63f3aa105dea217ef30d89581b65a4d527a19afc95ef5750be3890e8d3c5b837"
+checksum = "db09040cc89e461f1a265139777a2bde7f8d8c67c4936f700c63ce3e2904d468"
 dependencies = [
  "base64",
  "bitflags 2.9.4",
@@ -5618,14 +5617,15 @@ dependencies = [
 
 [[package]]
 name = "ron"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db09040cc89e461f1a265139777a2bde7f8d8c67c4936f700c63ce3e2904d468"
+checksum = "fd490c5b18261893f14449cbd28cb9c0b637aebf161cd77900bfdedaff21ec32"
 dependencies = [
- "base64",
  "bitflags 2.9.4",
+ "once_cell",
  "serde",
  "serde_derive",
+ "typeid",
  "unicode-ident",
 ]
 
@@ -5879,7 +5879,7 @@ version = "1.0.145"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "402a6f66d8c709116cf22f558eab210f5a50187f702eb4d7e5ef38d9a7f1c79c"
 dependencies = [
- "indexmap 2.11.3",
+ "indexmap 2.11.4",
  "itoa",
  "memchr",
  "ryu",
@@ -5917,7 +5917,7 @@ dependencies = [
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.11.3",
+ "indexmap 2.11.4",
  "schemars 0.9.0",
  "schemars 1.0.4",
  "serde",
@@ -6097,7 +6097,7 @@ dependencies = [
  "memmap2 0.9.8",
  "pkg-config",
  "rustix 1.1.2",
- "thiserror 2.0.16",
+ "thiserror 2.0.17",
  "wayland-backend",
  "wayland-client",
  "wayland-csd-frame",
@@ -6355,11 +6355,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.16"
+version = "2.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3467d614147380f2e4e374161426ff399c91084acd2363eaf549172b3d5e60c0"
+checksum = "f63587ca0f12b72a0600bcba1d40081f830876000bb46dd2337a3051618f4fc8"
 dependencies = [
- "thiserror-impl 2.0.16",
+ "thiserror-impl 2.0.17",
 ]
 
 [[package]]
@@ -6375,9 +6375,9 @@ dependencies = [
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.16"
+version = "2.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c5e1be1c48b9172ee610da68fd9cd2770e7a4056cb3fc98710ee6906f0c7960"
+checksum = "3ff15c8ecd7de3849db632e14d18d2571fa09dfc5ed93479bc4485c7a517c913"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6585,7 +6585,7 @@ version = "0.19.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
 dependencies = [
- "indexmap 2.11.3",
+ "indexmap 2.11.4",
  "toml_datetime 0.6.11",
  "winnow 0.5.40",
 ]
@@ -6596,7 +6596,7 @@ version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
- "indexmap 2.11.3",
+ "indexmap 2.11.4",
  "serde",
  "serde_spanned",
  "toml_datetime 0.6.11",
@@ -6609,7 +6609,7 @@ version = "0.23.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2ad0b7ae9cfeef5605163839cb9221f453399f15cfb5c10be9885fcf56611f9"
 dependencies = [
- "indexmap 2.11.3",
+ "indexmap 2.11.4",
  "toml_datetime 0.7.1",
  "toml_parser",
  "winnow 0.7.13",
@@ -6730,6 +6730,12 @@ checksum = "cb30dbbd9036155e74adad6812e9898d03ec374946234fbcebd5dfc7b9187b90"
 dependencies = [
  "rustc-hash 2.1.1",
 ]
+
+[[package]]
+name = "typeid"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c"
 
 [[package]]
 name = "typenum"
@@ -7298,7 +7304,7 @@ dependencies = [
  "bitflags 2.9.4",
  "cfg_aliases 0.1.1",
  "document-features",
- "indexmap 2.11.3",
+ "indexmap 2.11.4",
  "log",
  "naga",
  "once_cell",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,13 +20,13 @@ cosmic-greeter-config.workspace = true
 cosmic-greeter-daemon = { path = "daemon" }
 dirs = "6"
 libcosmic = { workspace = true, features = [
-    "autosize",
-    "winit",
-    "multi-window",
-    "desktop",
-    "wayland",
-    "tokio",
-    "dbus-config",
+  "autosize",
+  "winit",
+  "multi-window",
+  "desktop",
+  "wayland",
+  "tokio",
+  "dbus-config",
 ] }
 tracing.workspace = true
 tracing-journald = { workspace = true, optional = true }
@@ -41,15 +41,15 @@ xdg = "3.0"
 tokio = { workspace = true, features = ["full"] }
 wayland-client = "0.31.11"
 cosmic-settings-subscriptions = { git = "https://github.com/pop-os/cosmic-settings-subscriptions", default-features = false, features = [
-    "accessibility",
-    "cosmic_a11y_manager",
+  "accessibility",
+  "cosmic_a11y_manager",
 ] }
 cosmic-settings-daemon-config = { git = "https://github.com/pop-os/cosmic-settings-daemon", default-features = false, features = [
-    "greeter",
+  "greeter",
 ] }
 cctk = { git = "https://github.com/pop-os/cosmic-protocols", package = "cosmic-client-toolkit" }
 cosmic-protocols = { git = "https://github.com/pop-os/cosmic-protocols", default-features = false, features = [
-    "client",
+  "client",
 ] }
 
 # For network status using networkmanager feature
@@ -66,8 +66,8 @@ zbus = { workspace = true }
 clap_lex = "0.7"
 # Internationalization
 i18n-embed = { version = "0.16", features = [
-    "fluent-system",
-    "desktop-requester",
+  "fluent-system",
+  "desktop-requester",
 ] }
 i18n-embed-fl = "0.10"
 rust-embed = "8"
@@ -77,11 +77,11 @@ cosmic-randr-shell = { workspace = true }
 kdl.workspace = true
 color-eyre.workspace = true
 image = { version = "0.25", default-features = false, features = [
-    "jpeg",
-    "png",
-    "rayon",
-    "webp",
-    "hdr",
+  "jpeg",
+  "png",
+  "rayon",
+  "webp",
+  "hdr",
 ] }
 
 [dependencies.greetd_ipc]
@@ -109,7 +109,7 @@ members = ["cosmic-greeter-config", "daemon"]
 resolver = "2"
 
 [workspace.package]
-rust-version = "1.85.0"
+rust-version = "1.90.0"
 
 [workspace.dependencies]
 tracing = "0.1"
@@ -120,7 +120,7 @@ color-eyre = "0.6.5"
 # Fix zbus compilation by manually adding nix with user feature
 nix = { version = "0.30", features = ["user"] }
 pwd = "1.4.0"
-ron = "0.11"
+ron = "0.12"
 serde = "1"
 tokio = "1.47.1"
 zbus = "5"
@@ -136,7 +136,8 @@ git = "https://github.com/pop-os/cosmic-bg"
 default-features = false
 
 [workspace.dependencies.cosmic-comp-config]
-git = "https://github.com/pop-os/cosmic-comp"
+# git = "https://github.com/pop-os/cosmic-comp"
+path = "../cosmic-comp/cosmic-comp-config/"
 default-features = false
 features = ["output", "randr"]
 

--- a/daemon/src/lib.rs
+++ b/daemon/src/lib.rs
@@ -1,6 +1,4 @@
-use cosmic_comp_config::output::randr;
 use cosmic_config::CosmicConfigEntry;
-use kdl::KdlDocument;
 use std::{
     collections::BTreeMap,
     fs,
@@ -25,7 +23,8 @@ pub struct UserData {
     pub xkb_config_opt: Option<XkbConfig>,
     pub time_applet_config: TimeAppletConfig,
     pub accessibility_zoom: ZoomConfig,
-    pub kdl_output_lists: Vec<String>,
+    /// Path to the user's outputs.ron config file
+    pub output_config_path: Option<PathBuf>,
 }
 
 impl UserData {
@@ -179,17 +178,10 @@ impl UserData {
         };
 
         let xdg = xdg::BaseDirectories::new();
-        self.kdl_output_lists = xdg
-            .get_state_home()
-            .map(|mut s| {
-                s.push("cosmic-comp/outputs.ron");
-                let lists = randr::load_outputs(Some(&s));
-                lists
-                    .into_iter()
-                    .map(|l| KdlDocument::from(l).to_string())
-                    .collect()
-            })
-            .unwrap_or_default();
+        self.output_config_path = xdg.get_state_home().map(|mut s| {
+            s.push("cosmic-comp/outputs.ron");
+            s
+        });
 
         match cosmic_config::Config::new("com.system76.CosmicAppletTime", TimeAppletConfig::VERSION)
         {

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.85.1"
+channel = "1.90"
 components = ["clippy", "rustfmt"]


### PR DESCRIPTION
Previously greeter had to get the outputs.ron config from cosmic-comp-config and then match it to the available displays.

Now, it just sends the displays to the cosmic-comp-config and asks it to return the matching config. Moving the "match" logic to one place.


Currently this PR needs some cleanup (e.g. unnecessary freedesktop_entry_parser update). I'm just creating a draft to see if this approach is OK with the devs. This is part of this fix: https://github.com/pop-os/cosmic-comp/pull/1988

