### PR TITLE
i18n: Use "[0] now." on restarts/shutdowns

### DIFF
--- a/i18n/en/cosmic_greeter.ftl
+++ b/i18n/en/cosmic_greeter.ftl
@@ -11,18 +11,20 @@ type-username = Username:
 keyboard-layout = Keyboard layout
 restart = Restart
 restart-now = Restart now?
-restart-timeout = The system will restart automatically in
+restart-timeout = The system will restart automatically
   { $seconds ->
-    [1] 1 second.
-    *[other] {$seconds} seconds.
+    [0] now.
+    [1] in 1 second.
+    *[other] in {$seconds} seconds.
   }
 session = Session
 shutdown = Shut down
 shutdown-now = Shut down now?
-shutdown-timeout = The system will shut down automatically in
+shutdown-timeout = The system will shut down automatically
   { $seconds ->
-    [1] 1 second.
-    *[other] {$seconds} seconds.
+    [0] now.
+    [1] in 1 second.
+    *[other] in {$seconds} seconds.
   }
 suspend = Suspend
 user = User


### PR DESCRIPTION
- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

---

[greeter_restart.webm](https://github.com/user-attachments/assets/cdf5c52d-bf0e-42d1-9392-55a21580d577)

- Makes Greeter show "..will something **now**." instead of "..will something **in 0 seconds**."