### PR TITLE
Move xinit from Recommends to Suggests

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -27,8 +27,9 @@ Depends:
     dbus,
     ${misc:Depends},
     ${shlibs:Depends}
-Recommends: xinit
-Suggests: libpam-fprintd
+Suggests:
+    libpam-fprintd,
+    xinit
 Provides: x-display-manager
 Description: Cosmic Greeter
 


### PR DESCRIPTION
COSMIC Greeter is Wayland-based and does not rely on xinit in the default login path.

Moving xinit from Recommends to Suggests avoids installing legacy X11 tooling by default while keeping it available as an optional fallback.

Tested: boot, login, logout — no issues observed.


- [ X] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [ X] I understand these changes in full and will be able to respond to review comments.
- [ X] My change is accurately described in the commit message.
- [ X] My contribution is tested and working as described.
- [ X] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

