### PR TITLE
fix(upower): clamp battery percentage to 0-100 range

### DIFF
--- a/src/upower.rs
+++ b/src/upower.rs
@@ -43,6 +43,7 @@ pub async fn handler(msg_tx: &mut mpsc::Sender<Option<(String, f64)>>) -> Result
         let mut info_opt = None;
 
         if let Ok(percent) = dev.percentage().await {
+            let percent = percent.clamp(0.0, 100.0);
             if let Ok(icon_name) = dev.icon_name().await {
                 if !icon_name.is_empty() && !icon_name.eq("battery-missing-symbolic") {
                     info_opt = Some((icon_name, percent));


### PR DESCRIPTION
- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

## Summary

The battery applet and cosmic-settings both clamp UPower's battery percentage to [0.0, 100.0] before display. The greeter passes the raw value directly. During battery calibration or with buggy kernel drivers, UPower can briefly report values outside this range, which would display as e.g. "102%" on the login screen.

This adds a `.clamp(0.0, 100.0)` to match the applet (`app.rs:107`) and settings (`mod.rs:313`) behavior.

## Test plan

- [ ] Verify battery percentage displays correctly on login screen
- [ ] Verify battery icon still appears/disappears appropriately