### PR TITLE
locker: watch xkb_config for live layout updates and show active layout label

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -13,7 +13,7 @@ use cosmic::{
     widget,
 };
 use cosmic_config::{ConfigSet, CosmicConfigEntry};
-use cosmic_greeter_daemon::{BgSource, CosmicCompConfig, UserData};
+use cosmic_greeter_daemon::{BgSource, CosmicCompConfig, UserData, XkbConfig};
 use std::{collections::HashMap, sync::Arc};
 use wayland_client::protocol::wl_output::WlOutput;
 
@@ -65,6 +65,7 @@ pub enum Message {
     SessionLockEvent(SessionLockEvent),
     Tick,
     Tz(chrono_tz::Tz),
+    XkbConfigChanged(XkbConfig),
 }
 
 impl<M: From<Message> + Send + 'static> Common<M> {
@@ -200,52 +201,81 @@ impl<M: From<Message> + Send + 'static> Common<M> {
         }
     }
 
+    pub fn refresh_active_layouts(&mut self, xkb_config: &XkbConfig) {
+        // Guard against hostile/corrupt xkb_config payloads. Any process
+        // running as the same user can write to com.system76.CosmicComp/v1,
+        // so an attacker could feed us a multi-megabyte `layout` string to
+        // stall the locker UI in the O(N*M) match loop below.
+        const MAX_LAYOUT_LEN: usize = 1024;
+        const MAX_LAYOUTS: usize = 32;
+        if xkb_config.layout.len() > MAX_LAYOUT_LEN
+            || xkb_config.layout.split_terminator(',').count() > MAX_LAYOUTS
+        {
+            tracing::warn!(
+                len = xkb_config.layout.len(),
+                "refusing to parse oversized xkb_config.layout"
+            );
+            return;
+        }
+
+        let Some(keyboard_layouts) = self.layouts_opt.as_ref() else {
+            return;
+        };
+
+        let mut new_layouts: Vec<ActiveLayout> = Vec::new();
+        let config_layouts = xkb_config.layout.split_terminator(',');
+        let config_variants = xkb_config
+            .variant
+            .split_terminator(',')
+            .chain(std::iter::repeat(""));
+        'outer: for (config_layout, config_variant) in config_layouts.zip(config_variants) {
+            for xkb_layout in keyboard_layouts.layouts() {
+                if config_layout != xkb_layout.name() {
+                    continue;
+                }
+                if config_variant.is_empty() {
+                    new_layouts.push(ActiveLayout {
+                        description: xkb_layout.description().to_owned(),
+                        layout: config_layout.to_owned(),
+                        variant: config_variant.to_owned(),
+                    });
+                    continue 'outer;
+                }
+
+                let Some(xkb_variants) = xkb_layout.variants() else {
+                    continue;
+                };
+                for xkb_variant in xkb_variants {
+                    if config_variant != xkb_variant.name() {
+                        continue;
+                    }
+                    new_layouts.push(ActiveLayout {
+                        description: xkb_variant.description().to_owned(),
+                        layout: config_layout.to_owned(),
+                        variant: config_variant.to_owned(),
+                    });
+                    continue 'outer;
+                }
+            }
+        }
+
+        // Only replace the cache if parsing yielded something usable. An
+        // empty result means the file was either truly empty or had only
+        // unknown layouts, in which case keeping the last known-good state
+        // avoids wiping the dropdown + layout label until the next valid
+        // update arrives.
+        if !new_layouts.is_empty() {
+            self.active_layouts = new_layouts;
+            tracing::debug!(?self.active_layouts, "refreshed active layouts");
+        }
+    }
+
     pub fn update_user_data(&mut self, user_data: &UserData) {
         self.update_wallpapers(user_data);
 
         // From cosmic-applet-input-sources
-        if let Some(keyboard_layouts) = &self.layouts_opt {
-            if let Some(xkb_config) = &user_data.xkb_config_opt {
-                self.active_layouts.clear();
-                let config_layouts = xkb_config.layout.split_terminator(',');
-                let config_variants = xkb_config
-                    .variant
-                    .split_terminator(',')
-                    .chain(std::iter::repeat(""));
-                'outer: for (config_layout, config_variant) in config_layouts.zip(config_variants) {
-                    for xkb_layout in keyboard_layouts.layouts() {
-                        if config_layout != xkb_layout.name() {
-                            continue;
-                        }
-                        if config_variant.is_empty() {
-                            let active_layout = ActiveLayout {
-                                description: xkb_layout.description().to_owned(),
-                                layout: config_layout.to_owned(),
-                                variant: config_variant.to_owned(),
-                            };
-                            self.active_layouts.push(active_layout);
-                            continue 'outer;
-                        }
-
-                        let Some(xkb_variants) = xkb_layout.variants() else {
-                            continue;
-                        };
-                        for xkb_variant in xkb_variants {
-                            if config_variant != xkb_variant.name() {
-                                continue;
-                            }
-                            let active_layout = ActiveLayout {
-                                description: xkb_variant.description().to_owned(),
-                                layout: config_layout.to_owned(),
-                                variant: config_variant.to_owned(),
-                            };
-                            self.active_layouts.push(active_layout);
-                            continue 'outer;
-                        }
-                    }
-                }
-                tracing::info!("{:?}", self.active_layouts);
-            }
+        if let Some(xkb_config) = &user_data.xkb_config_opt {
+            self.refresh_active_layouts(xkb_config);
         }
     }
 
@@ -330,12 +360,33 @@ impl<M: From<Message> + Send + 'static> Common<M> {
             Message::Tz(tz) => {
                 self.time.set_tz(tz);
             }
+            Message::XkbConfigChanged(xkb_config) => {
+                self.refresh_active_layouts(&xkb_config);
+            }
         }
         Task::none()
     }
 
     pub fn subscription(&self) -> Subscription<Message> {
-        let mut subscriptions = Vec::with_capacity(3);
+        let mut subscriptions = Vec::new();
+
+        struct XkbConfigSubscription;
+        subscriptions.push(
+            cosmic_config::config_subscription(
+                std::any::TypeId::of::<XkbConfigSubscription>(),
+                "com.system76.CosmicComp".into(),
+                CosmicCompConfig::VERSION,
+            )
+            .map(|update: cosmic_config::Update<CosmicCompConfig>| {
+                if !update.errors.is_empty() {
+                    tracing::warn!(
+                        errors = ?update.errors,
+                        "errors loading com.system76.CosmicComp"
+                    );
+                }
+                Message::XkbConfigChanged(update.config.xkb_config)
+            }),
+        );
 
         subscriptions.push(event::listen_with(|event, status, id| match event {
             iced::Event::Keyboard(KeyEvent::KeyPressed {

--- a/src/common.rs
+++ b/src/common.rs
@@ -7,7 +7,7 @@ use cosmic::iced::runtime::core::window::Id as SurfaceId;
 use cosmic::iced::{self, Rectangle, Size, Subscription};
 use cosmic::widget;
 use cosmic_config::{ConfigSet, CosmicConfigEntry};
-use cosmic_greeter_daemon::{BgSource, CosmicCompConfig, UserData};
+use cosmic_greeter_daemon::{BgSource, CosmicCompConfig, UserData, XkbConfig};
 use std::collections::HashMap;
 use std::sync::Arc;
 use wayland_client::protocol::wl_output::WlOutput;
@@ -60,6 +60,7 @@ pub enum Message {
     SessionLockEvent(SessionLockEvent),
     Tick,
     Tz(jiff::tz::TimeZone),
+    XkbConfigChanged(XkbConfig),
 }
 
 impl<M: From<Message> + Send + 'static> Common<M> {
@@ -195,52 +196,55 @@ impl<M: From<Message> + Send + 'static> Common<M> {
         }
     }
 
+    pub fn refresh_active_layouts(&mut self, xkb_config: &XkbConfig) {
+        let Some(keyboard_layouts) = self.layouts_opt.as_ref() else {
+            return;
+        };
+
+        self.active_layouts.clear();
+        let config_layouts = xkb_config.layout.split_terminator(',');
+        let config_variants = xkb_config
+            .variant
+            .split_terminator(',')
+            .chain(std::iter::repeat(""));
+        'outer: for (config_layout, config_variant) in config_layouts.zip(config_variants) {
+            for xkb_layout in keyboard_layouts.layouts() {
+                if config_layout != xkb_layout.name() {
+                    continue;
+                }
+                if config_variant.is_empty() {
+                    self.active_layouts.push(ActiveLayout {
+                        description: xkb_layout.description().to_owned(),
+                        layout: config_layout.to_owned(),
+                        variant: config_variant.to_owned(),
+                    });
+                    continue 'outer;
+                }
+
+                let Some(xkb_variants) = xkb_layout.variants() else {
+                    continue;
+                };
+                for xkb_variant in xkb_variants {
+                    if config_variant != xkb_variant.name() {
+                        continue;
+                    }
+                    self.active_layouts.push(ActiveLayout {
+                        description: xkb_variant.description().to_owned(),
+                        layout: config_layout.to_owned(),
+                        variant: config_variant.to_owned(),
+                    });
+                    continue 'outer;
+                }
+            }
+        }
+    }
+
     pub fn update_user_data(&mut self, user_data: &UserData) {
         self.update_wallpapers(user_data);
 
         // From cosmic-applet-input-sources
-        if let Some(keyboard_layouts) = &self.layouts_opt
-            && let Some(xkb_config) = &user_data.xkb_config_opt
-        {
-            self.active_layouts.clear();
-            let config_layouts = xkb_config.layout.split_terminator(',');
-            let config_variants = xkb_config
-                .variant
-                .split_terminator(',')
-                .chain(std::iter::repeat(""));
-            'outer: for (config_layout, config_variant) in config_layouts.zip(config_variants) {
-                for xkb_layout in keyboard_layouts.layouts() {
-                    if config_layout != xkb_layout.name() {
-                        continue;
-                    }
-                    if config_variant.is_empty() {
-                        let active_layout = ActiveLayout {
-                            description: xkb_layout.description().to_owned(),
-                            layout: config_layout.to_owned(),
-                            variant: config_variant.to_owned(),
-                        };
-                        self.active_layouts.push(active_layout);
-                        continue 'outer;
-                    }
-
-                    let Some(xkb_variants) = xkb_layout.variants() else {
-                        continue;
-                    };
-                    for xkb_variant in xkb_variants {
-                        if config_variant != xkb_variant.name() {
-                            continue;
-                        }
-                        let active_layout = ActiveLayout {
-                            description: xkb_variant.description().to_owned(),
-                            layout: config_layout.to_owned(),
-                            variant: config_variant.to_owned(),
-                        };
-                        self.active_layouts.push(active_layout);
-                        continue 'outer;
-                    }
-                }
-            }
-            tracing::info!("{:?}", self.active_layouts);
+        if let Some(xkb_config) = &user_data.xkb_config_opt {
+            self.refresh_active_layouts(xkb_config);
         }
     }
 
@@ -322,12 +326,33 @@ impl<M: From<Message> + Send + 'static> Common<M> {
             Message::Tz(tz) => {
                 self.time.set_tz(tz);
             }
+            Message::XkbConfigChanged(xkb_config) => {
+                self.refresh_active_layouts(&xkb_config);
+            }
         }
         Task::none()
     }
 
     pub fn subscription(&self) -> Subscription<Message> {
-        let mut subscriptions = Vec::with_capacity(3);
+        let mut subscriptions = Vec::with_capacity(4);
+
+        struct XkbConfigSubscription;
+        subscriptions.push(
+            cosmic_config::config_subscription(
+                std::any::TypeId::of::<XkbConfigSubscription>(),
+                "com.system76.CosmicComp".into(),
+                CosmicCompConfig::VERSION,
+            )
+            .map(|update: cosmic_config::Update<CosmicCompConfig>| {
+                if !update.errors.is_empty() {
+                    tracing::warn!(
+                        errors = ?update.errors,
+                        "errors loading com.system76.CosmicComp"
+                    );
+                }
+                Message::XkbConfigChanged(update.config.xkb_config)
+            }),
+        );
 
         subscriptions.push(event::listen_with(|event, status, id| match event {
             iced::Event::Keyboard(KeyEvent::KeyPressed {

--- a/src/locker.rs
+++ b/src/locker.rs
@@ -414,8 +414,44 @@ impl App {
                     .width(Length::Fixed(240.0))
             };
 
+            let layout_label = self.common.active_layouts.first().map(|l| {
+                // Layout codes like "us", "ru", "de" become "US"/"RU"/"DE".
+                // Cap at 2 chars so exotic codes like "latam"/"epo" don't
+                // make the button jump width between switches.
+                l.layout.chars().take(2).collect::<String>().to_uppercase()
+            });
+            // Match the bare-icon sibling buttons (suspend, etc.) in height.
+            // libcosmic's default icon size is 16 (see cosmic::widget::icon),
+            // so a plain `button::custom(icon)` renders at 16 + 2*padding.
+            // Our icon+text row would otherwise be taller because text at
+            // its default body size has a line-box that exceeds 16 px.
+            // Pinning the container to the icon height and using a text
+            // size whose line-box fits inside 16 keeps the keyboard button
+            // flush with the adjacent circular buttons.
+            const ICON_SIZE: u16 = 16;
+            // Fixed label width so the button doesn't resize when switching
+            // between layout codes of different character widths ("RU" vs "EN").
+            const LABEL_WIDTH: f32 = 20.0;
+            let keyboard_button_content: Element<Message> = match layout_label {
+                Some(label) => widget::container(
+                    iced::widget::row![
+                        widget::icon::from_name("input-keyboard-symbolic").size(ICON_SIZE),
+                        widget::container(widget::text(label).size(12))
+                            .width(iced::Length::Fixed(LABEL_WIDTH))
+                            .align_x(iced::Alignment::Center),
+                    ]
+                    .spacing(4.0)
+                    .align_y(iced::Alignment::Center),
+                )
+                .height(iced::Length::Fixed(f32::from(ICON_SIZE)))
+                .align_y(iced::Alignment::Center)
+                .into(),
+                None => widget::icon::from_name("input-keyboard-symbolic")
+                    .size(ICON_SIZE)
+                    .into(),
+            };
             let mut input_button = widget::popover(
-                widget::button::custom(widget::icon::from_name("input-keyboard-symbolic"))
+                widget::button::custom(keyboard_button_content)
                     .padding(12.0)
                     .on_press(Message::DropdownToggle(Dropdown::Keyboard)),
             )

--- a/src/locker.rs
+++ b/src/locker.rs
@@ -406,8 +406,36 @@ impl App {
                     .width(Length::Fixed(240.0))
             };
 
+            let layout_label = self.common.active_layouts.first().map(|l| {
+                // Layout codes like "us", "ru", "de" become "US"/"RU"/"DE".
+                // Cap at 2 chars so exotic codes like "latam"/"epo" don't
+                // make the button jump width between switches.
+                l.layout.chars().take(2).collect::<String>().to_uppercase()
+            });
+            // Match sibling bare-icon buttons in height (libcosmic icon default).
+            const ICON_SIZE: u16 = 16;
+            // Fixed width so "RU"/"EN" don't resize the button between switches.
+            const LABEL_WIDTH: f32 = 20.0;
+            let keyboard_button_content: Element<Message> = match layout_label {
+                Some(label) => widget::container(
+                    iced::widget::row![
+                        widget::icon::from_name("input-keyboard-symbolic").size(ICON_SIZE),
+                        widget::container(widget::text(label).size(12))
+                            .width(iced::Length::Fixed(LABEL_WIDTH))
+                            .align_x(iced::Alignment::Center),
+                    ]
+                    .spacing(4.0)
+                    .align_y(iced::Alignment::Center),
+                )
+                .height(iced::Length::Fixed(f32::from(ICON_SIZE)))
+                .align_y(iced::Alignment::Center)
+                .into(),
+                None => widget::icon::from_name("input-keyboard-symbolic")
+                    .size(ICON_SIZE)
+                    .into(),
+            };
             let mut input_button = widget::popover(
-                widget::button::custom(widget::icon::from_name("input-keyboard-symbolic"))
+                widget::button::custom(keyboard_button_content)
                     .padding(12.0)
                     .on_press(Message::DropdownToggle(Dropdown::Keyboard)),
             )


### PR DESCRIPTION
- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

## Summary
- Fixes https://github.com/pop-os/cosmic-greeter/issues/461
- Subscribe to `com.system76.CosmicComp` config changes so the locker
  refreshes `active_layouts` whenever `xkb_config` is modified at runtime.
  Previously the locker cached layouts at startup and never updated,
  leaving the dropdown checkmark pointing at a stale layout after any
  switch.
- Show the active layout code (EN/RU/…) next to the keyboard icon on
  the lock screen so users can see which layout is active without opening
  the dropdown.

This PR stands on its own — any tool that changes `xkb_config` (Settings →
Keyboard, `busctl`, etc.) will trigger the locker UI refresh. The companion
pop-os/cosmic-comp#2296 additionally enables `Super+Space` to switch
layouts under session lock, completing the user-facing flow.

## Test plan

- [ ] Change `xkb_config` at runtime (e.g. via Settings → Keyboard → Input Sources,
      or directly through cosmic-config). Lock the screen — the dropdown
      checkmark and the layout label both reflect the new layout.
- [ ] Lock the screen with multiple layouts configured — the active layout code
      (EN/RU/…) renders next to the keyboard icon.
- [ ] Edge case: empty `xkb_config.layout` — only the icon renders, no label, no crash.
- [ ] (Once pop-os/cosmic-comp#2296 is merged) Use `Super+Space` on the lock
      screen to switch layouts — the dropdown checkmark and the layout label
      update live.
