### PR TITLE
Autofill SOURCE_DATE_EPOCH and SOURCE_GIT_HASH during vendoring

### DIFF
--- a/justfile
+++ b/justfile
@@ -92,15 +92,15 @@ vendor:
     echo 'directory = "vendor"' >> .cargo/config.toml
     echo >> .cargo/config.toml
     echo '[env]' >> .cargo/config.toml
-    if [ -n "${SOURCE_DATE_EPOCH}" ]
-    then
-        source_date="$(date -d "@${SOURCE_DATE_EPOCH}" "+%Y-%m-%d")"
-        echo "VERGEN_GIT_COMMIT_DATE = \"${source_date}\"" >> .cargo/config.toml
+    if [ -z "${SOURCE_DATE_EPOCH}" ]; then
+        SOURCE_DATE_EPOCH=$(git log -1 --format='%ct')
     fi
-    if [ -n "${SOURCE_GIT_HASH}" ]
-    then
-        echo "VERGEN_GIT_SHA = \"${SOURCE_GIT_HASH}\"" >> .cargo/config.toml
+    if [ -z "${SOURCE_GIT_HASH}"]; then
+        SOURCE_GIT_HASH=$(git rev-parse HEAD)
     fi
+    source_date="$(date -d "@${SOURCE_DATE_EPOCH}" "+%Y-%m-%d")"
+    echo "VERGEN_GIT_COMMIT_DATE = \"${source_date}\"" >> .cargo/config.toml
+    echo "VERGEN_GIT_SHA = \"${SOURCE_GIT_HASH}\"" >> .cargo/config.toml
     tar pcf vendor.tar .cargo vendor
     rm -rf .cargo vendor
 


### PR DESCRIPTION
- [X] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [X] I understand these changes in full and will be able to respond to review comments.
- [X] My change is accurately described in the commit message.
- [X] My contribution is tested and working as described.
- [X] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

This is a small fix to autofill correct defaults for SOURCE_DATE_EPOCH and SOURCE_GIT_HASH when running `just vendor`. See https://github.com/pop-os/cosmic-epoch/issues/3571 for further context.