### PR TITLE
Fix typo in 'just vendor' script

### DIFF
--- a/justfile
+++ b/justfile
@@ -95,7 +95,7 @@ vendor:
     if [ -z "${SOURCE_DATE_EPOCH}" ]; then
         SOURCE_DATE_EPOCH=$(git log -1 --format='%ct')
     fi
-    if [ -z "${SOURCE_GIT_HASH}"]; then
+    if [ -z "${SOURCE_GIT_HASH}" ]; then
         SOURCE_GIT_HASH=$(git rev-parse HEAD)
     fi
     source_date="$(date -d "@${SOURCE_DATE_EPOCH}" "+%Y-%m-%d")"


### PR DESCRIPTION
- [X] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [X] I understand these changes in full and will be able to respond to review comments.
- [X] My change is accurately described in the commit message.
- [X] My contribution is tested and working as described.
- [X] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

This fixes a typo that I introduced in #464, which caused bash to complain of a syntax error if `SOURCE_GIT_HASH` has been explicitly set.