### PR TITLE
Use libcosmic indeterminate_circular spinner for authentication

### DIFF
--- a/src/greeter.rs
+++ b/src/greeter.rs
@@ -390,7 +390,6 @@ pub enum Message {
     HighContrast(bool),
     InvertColors(bool),
     WaylandUpdate(WaylandUpdate),
-    SpinnerTick,
 }
 
 impl From<common::Message> for Message {
@@ -420,8 +419,6 @@ pub struct App {
 
     accessibility: Accessibility,
     authenticating: bool,
-    spinner_rotation: f32,
-    spinner_handle: Option<cosmic::iced::task::Handle>,
 }
 
 #[derive(Default)]
@@ -902,14 +899,7 @@ impl App {
                         widget::row::with_capacity(2)
                             .spacing(8.0)
                             .align_y(Alignment::Center)
-                            .push(
-                                widget::icon::from_name("process-working-symbolic")
-                                    .size(16)
-                                    .icon()
-                                    .rotation(iced::Rotation::Floating(iced::Radians(
-                                        self.spinner_rotation.to_radians(),
-                                    ))),
-                            )
+                            .push(widget::indeterminate_circular().size(16.0).bar_height(2.0))
                             .push(widget::text(fl!("authenticating"))),
                     )
                     .width(Length::Fill)
@@ -1173,8 +1163,6 @@ impl cosmic::Application for App {
             randr_list: None,
             surface_id_pairs: Vec::new(),
             authenticating: false,
-            spinner_rotation: 0.0,
-            spinner_handle: None,
         };
         (app, Task::batch(tasks))
     }
@@ -1482,38 +1470,11 @@ impl cosmic::Application for App {
                 self.common.error_opt = None;
                 self.authenticating = true;
                 self.send_request(Request::PostAuthMessageResponse { response });
-
-                // Start spinner animation if not already running
-                if self.spinner_handle.is_none() {
-                    let (spinner_task, handle) =
-                        cosmic::task::stream(cosmic::iced::stream::channel(
-                            1,
-                            |mut msg_tx: iced::futures::channel::mpsc::Sender<_>| async move {
-                                let mut interval = time::interval(Duration::from_millis(16)); // ~60fps
-                                loop {
-                                    msg_tx
-                                        .send(cosmic::Action::App(Message::SpinnerTick))
-                                        .await
-                                        .unwrap();
-                                    interval.tick().await;
-                                }
-                            },
-                        ))
-                        .abortable();
-                    self.spinner_handle = Some(handle);
-                    return spinner_task;
-                }
             }
             Message::Login => {
                 self.common.prompt_opt = None;
                 self.common.error_opt = None;
                 self.authenticating = false;
-
-                // Stop spinner animation
-                if let Some(handle) = self.spinner_handle.take() {
-                    handle.abort();
-                }
-                self.spinner_rotation = 0.0;
 
                 match self.flags.sessions.get(&self.selected_session).cloned() {
                     Some((cmd, env)) => {
@@ -1526,12 +1487,6 @@ impl cosmic::Application for App {
             Message::Error(error) => {
                 self.common.error_opt = Some(error);
                 self.authenticating = false;
-
-                // Stop spinner animation
-                if let Some(handle) = self.spinner_handle.take() {
-                    handle.abort();
-                }
-                self.spinner_rotation = 0.0;
 
                 self.send_request(Request::CancelSession);
             }
@@ -1862,10 +1817,6 @@ impl cosmic::Application for App {
                     Point::new(0., 32.)
                 };
                 return reposition_subsurface(*subsurface_id, loc.x as i32, loc.y as i32);
-            }
-            Message::SpinnerTick => {
-                // Update spinner rotation angle (360 degrees per second = 6 degrees per frame at 60fps)
-                self.spinner_rotation = (self.spinner_rotation + 6.0) % 360.0;
             }
         }
         Task::none()

--- a/src/locker.rs
+++ b/src/locker.rs
@@ -274,7 +274,6 @@ pub enum Message {
     Error(String),
     Lock,
     Unlock,
-    SpinnerTick,
 }
 
 impl From<common::Message> for Message {
@@ -312,8 +311,6 @@ pub struct App {
     inhibit_opt: Option<Arc<OwnedFd>>,
     value_tx_opt: Option<mpsc::Sender<String>>,
     authenticating: bool,
-    spinner_rotation: f32,
-    spinner_handle: Option<cosmic::iced::task::Handle>,
 }
 
 impl App {
@@ -566,14 +563,7 @@ impl App {
                         widget::row::with_capacity(2)
                             .spacing(8.0)
                             .align_y(Alignment::Center)
-                            .push(
-                                widget::icon::from_name("process-working-symbolic")
-                                    .size(16)
-                                    .icon()
-                                    .rotation(iced::Rotation::Floating(iced::Radians(
-                                        self.spinner_rotation.to_radians(),
-                                    ))),
-                            )
+                            .push(widget::indeterminate_circular().size(16.0).bar_height(2.0))
                             .push(widget::text(fl!("authenticating"))),
                     )
                     .width(Length::Fill)
@@ -675,8 +665,6 @@ impl cosmic::Application for App {
             inhibit_opt: None,
             value_tx_opt: None,
             authenticating: false,
-            spinner_rotation: 0.0,
-            spinner_handle: None,
         };
 
         let task = if cfg!(feature = "logind") {
@@ -1047,39 +1035,10 @@ impl cosmic::Application for App {
                 self.authenticating = true;
                 match self.value_tx_opt.take() {
                     Some(value_tx) => {
-                        // Start spinner animation if not already running
-                        if self.spinner_handle.is_none() {
-                            let (spinner_task, handle) =
-                                cosmic::task::stream(cosmic::iced::stream::channel(
-                                    1,
-                                    |mut msg_tx: futures::channel::mpsc::Sender<_>| async move {
-                                        let mut interval =
-                                            tokio::time::interval(Duration::from_millis(16)); // ~60fps
-                                        loop {
-                                            msg_tx
-                                                .send(cosmic::Action::App(Message::SpinnerTick))
-                                                .await
-                                                .unwrap();
-                                            interval.tick().await;
-                                        }
-                                    },
-                                ))
-                                .abortable();
-                            self.spinner_handle = Some(handle);
-
-                            return Task::batch([
-                                spinner_task,
-                                cosmic::task::future(async move {
-                                    value_tx.send(value).await.unwrap();
-                                    Message::Channel(value_tx)
-                                }),
-                            ]);
-                        } else {
-                            return cosmic::task::future(async move {
-                                value_tx.send(value).await.unwrap();
-                                Message::Channel(value_tx)
-                            });
-                        }
+                        return cosmic::task::future(async move {
+                            value_tx.send(value).await.unwrap();
+                            Message::Channel(value_tx)
+                        });
                     }
                     None => tracing::warn!("tried to submit when value_tx_opt not set"),
                 }
@@ -1098,16 +1057,6 @@ impl cosmic::Application for App {
             Message::Error(error) => {
                 self.common.error_opt = Some(error);
                 self.authenticating = false;
-
-                // Stop spinner animation
-                if let Some(handle) = self.spinner_handle.take() {
-                    handle.abort();
-                }
-                self.spinner_rotation = 0.0;
-            }
-            Message::SpinnerTick => {
-                // Update spinner rotation angle (360 degrees per second = 6 degrees per frame at 60fps)
-                self.spinner_rotation = (self.spinner_rotation + 6.0) % 360.0;
             }
             Message::Lock => match self.state {
                 State::Unlocked => {
@@ -1119,10 +1068,6 @@ impl cosmic::Application for App {
                     self.value_tx_opt = None;
                     // Reset authenticating state
                     self.authenticating = false;
-                    if let Some(handle) = self.spinner_handle.take() {
-                        handle.abort();
-                    }
-                    self.spinner_rotation = 0.0;
                     // Try to create lockfile when locking
                     if let Some(ref lockfile) = self.flags.lockfile_opt
                         && let Err(err) = fs::File::create(lockfile)
@@ -1151,11 +1096,6 @@ impl cosmic::Application for App {
                         // Stop authenticating
                         self.authenticating = false;
 
-                        // Stop spinner animation
-                        if let Some(handle) = self.spinner_handle.take() {
-                            handle.abort();
-                        }
-                        self.spinner_rotation = 0.0;
                         // Try to delete lockfile when unlocking
                         if let Some(ref lockfile) = self.flags.lockfile_opt
                             && let Err(err) = fs::remove_file(lockfile)


### PR DESCRIPTION
This is a follow up on #349 to replace the manual "loading spinner" with the recently implemented indeterminate_circular spinner from libcosmic.


https://github.com/user-attachments/assets/8f5f6af9-6dbb-4cea-8c1b-b110b5bb0014




- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

