### PR TITLE
Fix keyboard layout switching in the greeter

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -7,7 +7,7 @@ use cosmic::iced::runtime::core::window::Id as SurfaceId;
 use cosmic::iced::{self, Rectangle, Size, Subscription};
 use cosmic::widget;
 use cosmic_config::{ConfigSet, CosmicConfigEntry};
-use cosmic_greeter_daemon::{BgSource, CosmicCompConfig, UserData};
+use cosmic_greeter_daemon::{BgSource, CosmicCompConfig, UserData, XkbConfig};
 use std::collections::HashMap;
 use std::sync::Arc;
 use wayland_client::protocol::wl_output::WlOutput;
@@ -60,6 +60,7 @@ pub enum Message {
     SessionLockEvent(SessionLockEvent),
     Tick,
     Tz(jiff::tz::TimeZone),
+    XkbConfigChanged(XkbConfig),
 }
 
 impl<M: From<Message> + Send + 'static> Common<M> {
@@ -195,52 +196,58 @@ impl<M: From<Message> + Send + 'static> Common<M> {
         }
     }
 
+    // From cosmic-applet-input-sources
+    pub fn refresh_active_layouts(&mut self, xkb_config: &XkbConfig) {
+        let Some(keyboard_layouts) = &self.layouts_opt else {
+            return;
+        };
+
+        self.active_layouts.clear();
+        let config_layouts = xkb_config.layout.split_terminator(',');
+        let config_variants = xkb_config
+            .variant
+            .split_terminator(',')
+            .chain(std::iter::repeat(""));
+        'outer: for (config_layout, config_variant) in config_layouts.zip(config_variants) {
+            for xkb_layout in keyboard_layouts.layouts() {
+                if config_layout != xkb_layout.name() {
+                    continue;
+                }
+                if config_variant.is_empty() {
+                    let active_layout = ActiveLayout {
+                        description: xkb_layout.description().to_owned(),
+                        layout: config_layout.to_owned(),
+                        variant: config_variant.to_owned(),
+                    };
+                    self.active_layouts.push(active_layout);
+                    continue 'outer;
+                }
+
+                let Some(xkb_variants) = xkb_layout.variants() else {
+                    continue;
+                };
+                for xkb_variant in xkb_variants {
+                    if config_variant != xkb_variant.name() {
+                        continue;
+                    }
+                    let active_layout = ActiveLayout {
+                        description: xkb_variant.description().to_owned(),
+                        layout: config_layout.to_owned(),
+                        variant: config_variant.to_owned(),
+                    };
+                    self.active_layouts.push(active_layout);
+                    continue 'outer;
+                }
+            }
+        }
+        tracing::info!("{:?}", self.active_layouts);
+    }
+
     pub fn update_user_data(&mut self, user_data: &UserData) {
         self.update_wallpapers(user_data);
 
-        // From cosmic-applet-input-sources
-        if let Some(keyboard_layouts) = &self.layouts_opt
-            && let Some(xkb_config) = &user_data.xkb_config_opt
-        {
-            self.active_layouts.clear();
-            let config_layouts = xkb_config.layout.split_terminator(',');
-            let config_variants = xkb_config
-                .variant
-                .split_terminator(',')
-                .chain(std::iter::repeat(""));
-            'outer: for (config_layout, config_variant) in config_layouts.zip(config_variants) {
-                for xkb_layout in keyboard_layouts.layouts() {
-                    if config_layout != xkb_layout.name() {
-                        continue;
-                    }
-                    if config_variant.is_empty() {
-                        let active_layout = ActiveLayout {
-                            description: xkb_layout.description().to_owned(),
-                            layout: config_layout.to_owned(),
-                            variant: config_variant.to_owned(),
-                        };
-                        self.active_layouts.push(active_layout);
-                        continue 'outer;
-                    }
-
-                    let Some(xkb_variants) = xkb_layout.variants() else {
-                        continue;
-                    };
-                    for xkb_variant in xkb_variants {
-                        if config_variant != xkb_variant.name() {
-                            continue;
-                        }
-                        let active_layout = ActiveLayout {
-                            description: xkb_variant.description().to_owned(),
-                            layout: config_layout.to_owned(),
-                            variant: config_variant.to_owned(),
-                        };
-                        self.active_layouts.push(active_layout);
-                        continue 'outer;
-                    }
-                }
-            }
-            tracing::info!("{:?}", self.active_layouts);
+        if let Some(xkb_config) = &user_data.xkb_config_opt {
+            self.refresh_active_layouts(xkb_config);
         }
     }
 
@@ -322,12 +329,33 @@ impl<M: From<Message> + Send + 'static> Common<M> {
             Message::Tz(tz) => {
                 self.time.set_tz(tz);
             }
+            Message::XkbConfigChanged(xkb_config) => {
+                self.refresh_active_layouts(&xkb_config);
+            }
         }
         Task::none()
     }
 
     pub fn subscription(&self) -> Subscription<Message> {
-        let mut subscriptions = Vec::with_capacity(3);
+        let mut subscriptions = Vec::with_capacity(4);
+
+        struct XkbConfigSubscription;
+        subscriptions.push(
+            cosmic_config::config_subscription(
+                std::any::TypeId::of::<XkbConfigSubscription>(),
+                "com.system76.CosmicComp".into(),
+                CosmicCompConfig::VERSION,
+            )
+            .map(|update: cosmic_config::Update<CosmicCompConfig>| {
+                if !update.errors.is_empty() {
+                    tracing::warn!(
+                        "errors loading com.system76.CosmicComp config: {:?}",
+                        update.errors
+                    );
+                }
+                Message::XkbConfigChanged(update.config.xkb_config)
+            }),
+        );
 
         subscriptions.push(event::listen_with(|event, status, id| match event {
             iced::Event::Keyboard(KeyEvent::KeyPressed {

--- a/src/greeter.rs
+++ b/src/greeter.rs
@@ -372,6 +372,8 @@ pub enum Message {
         randr: Arc<Result<List, cosmic_randr_shell::Error>>,
     },
     Heartbeat,
+    /// Cycle to the next keyboard layout (cosmic-comp `Super+Space` shortcut).
+    InputSourceSwitch,
     KeyboardLayout(usize),
     Login,
     Reconnect,
@@ -1533,6 +1535,14 @@ impl cosmic::Application for App {
                     self.dropdown_opt = Some(dropdown);
                 }
             }
+            Message::InputSourceSwitch => {
+                // Cycle to the next layout, matching cosmic-settings-daemon's
+                // behaviour (move the active layout to the back of the list).
+                if self.common.active_layouts.len() > 1 {
+                    self.common.active_layouts.rotate_left(1);
+                    self.set_xkb_config();
+                }
+            }
             Message::KeyboardLayout(layout_i) => {
                 if layout_i < self.common.active_layouts.len() {
                     self.common.active_layouts.swap(0, layout_i);
@@ -1844,6 +1854,7 @@ impl cosmic::Application for App {
     fn subscription(&self) -> Subscription<Self::Message> {
         Subscription::batch([
             self.common.subscription().map(Message::from),
+            crate::input_source::subscription().map(|()| Message::InputSourceSwitch),
             ipc::subscription(),
             wayland::a11y_subscription().map(Message::WaylandUpdate),
             listen_with(|event, _status, id| match event {

--- a/src/input_source.rs
+++ b/src/input_source.rs
@@ -1,0 +1,75 @@
+// Copyright 2026 System76 <info@system76.com>
+// SPDX-License-Identifier: GPL-3.0-only
+
+//! Minimal `com.system76.CosmicSettingsDaemon` service for the greeter session.
+//!
+//! `Super+Space` (switch keyboard layout) is handled by cosmic-comp, which
+//! reacts to the shortcut by spawning the configured `system_actions` command:
+//!
+//! ```text
+//! busctl --user call com.system76.CosmicSettingsDaemon \
+//!     /com/system76/CosmicSettingsDaemon \
+//!     com.system76.CosmicSettingsDaemon InputSourceSwitch
+//! ```
+//!
+//! In a normal user session that call is serviced by cosmic-settings-daemon,
+//! which rotates the active keyboard layout. cosmic-settings-daemon does not run
+//! inside the greeter session, so the call has no receiver and the shortcut does
+//! nothing. We provide the `InputSourceSwitch` method ourselves and let the
+//! greeter perform the same layout rotation it does for the dropdown.
+
+use cosmic::iced::futures::SinkExt;
+use cosmic::iced::futures::channel::mpsc;
+use cosmic::iced::{Subscription, stream};
+use std::any::TypeId;
+use std::future::pending;
+use zbus::connection::Builder;
+
+/// D-Bus object exposing the subset of `com.system76.CosmicSettingsDaemon` that
+/// cosmic-comp's `Super+Space` shortcut relies on.
+struct InputSource {
+    msg_tx: mpsc::Sender<()>,
+}
+
+#[zbus::interface(name = "com.system76.CosmicSettingsDaemon")]
+impl InputSource {
+    /// Cycle to the next keyboard layout. Forwarded to the greeter's update
+    /// loop, which rotates the active layouts and applies the new xkb config.
+    async fn input_source_switch(&self) {
+        if let Err(err) = self.msg_tx.clone().send(()).await {
+            tracing::warn!("failed to forward InputSourceSwitch: {}", err);
+        }
+    }
+}
+
+async fn serve(msg_tx: mpsc::Sender<()>) -> zbus::Result<()> {
+    let _conn = Builder::session()?
+        .name("com.system76.CosmicSettingsDaemon")?
+        .serve_at("/com/system76/CosmicSettingsDaemon", InputSource { msg_tx })?
+        .build()
+        .await?;
+
+    // Hold the connection (and therefore the bus name) for the greeter's
+    // lifetime so the shortcut keeps working.
+    pending::<()>().await;
+    Ok(())
+}
+
+/// Serve a minimal `com.system76.CosmicSettingsDaemon` on the session bus so the
+/// `Super+Space` keyboard-layout shortcut works inside the greeter. Each
+/// `InputSourceSwitch` call yields a unit value.
+pub fn subscription() -> Subscription<()> {
+    struct InputSourceSubscription;
+
+    Subscription::run_with(TypeId::of::<InputSourceSubscription>(), |_| {
+        stream::channel(16, |msg_tx| async move {
+            if let Err(err) = serve(msg_tx).await {
+                tracing::warn!("input source switch service error: {}", err);
+            }
+
+            // Don't respawn the service on failure (e.g. the name is already
+            // owned by a real cosmic-settings-daemon).
+            pending::<()>().await
+        })
+    })
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,8 @@ mod wayland;
 
 mod common;
 
+mod input_source;
+
 mod localize;
 
 #[cfg(feature = "logind")]


### PR DESCRIPTION
Fixes pop-os/cosmic-greeter#461
Fixes pop-os/cosmic-greeter#360

- Keep the layout dropdown in sync after a switch when using cosmic-greeter after locking an already running session by refreshing on runtime xkb config changes (#461).
- Make `Super+Space` work in the greeter (#360): the greeter now serves the `InputSourceSwitch` D-Bus method itself and rotates the layout.

`Super+Space` is dispatched by cosmic-comp to `com.system76.CosmicSettingsDaemon`, which doesn't run in the greeter. So on a fresh boot with no prior login the shortcut hit nothing. The greeter now owns that name and handles the call itself.


- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

