### PR TITLE
Persist greeter-selected keyboard layout into the authenticated user's session

### DIFF
--- a/daemon/src/main.rs
+++ b/daemon/src/main.rs
@@ -1,7 +1,8 @@
 use color_eyre::eyre::Context;
-use cosmic_greeter_daemon::{UserData, UserFilter};
+use cosmic_config::{ConfigSet, CosmicConfigEntry};
+use cosmic_greeter_daemon::{CosmicCompConfig, UserData, UserFilter, XkbConfig};
 use std::error::Error;
-use std::ffi::CString;
+use std::ffi::{CString, OsString};
 use std::future::pending;
 use std::{env, io};
 use tracing::metadata::LevelFilter;
@@ -17,11 +18,38 @@ use zbus::connection::Builder;
 fn run_as_user<F: FnOnce() -> T, T>(user: &pwd::Passwd, f: F) -> Result<T, io::Error> {
     use nix::unistd::{Gid, Uid, getgroups, initgroups, setegid, seteuid, setgroups};
 
-    // Save root HOME
-    let root_home_opt = env::var_os("HOME");
+    // Guard that restores the root identity (uid, gid, supplementary groups and
+    // HOME) when it is dropped. Arming this before we drop privileges means a
+    // panic anywhere in the switch or in `f` still restores root on unwind,
+    // rather than leaving the process stuck with another identity for the next
+    // request it serves.
+    struct RestoreRoot {
+        root_groups: Vec<Gid>,
+        root_home_opt: Option<OsString>,
+    }
+    impl Drop for RestoreRoot {
+        fn drop(&mut self) {
+            // Restore uid/gid first so we have the privilege to restore groups.
+            seteuid(Uid::from_raw(0)).expect("failed to restore root uid");
+            setegid(Gid::from_raw(0)).expect("failed to restore root gid");
+            setgroups(&self.root_groups).expect("failed to restore root supplementary groups");
+            match self.root_home_opt.take() {
+                Some(root_home) => unsafe {
+                    env::set_var("HOME", root_home);
+                },
+                None => unsafe {
+                    env::remove_var("HOME");
+                },
+            }
+        }
+    }
 
-    // Save root groups
-    let root_groups = getgroups().expect("failed to get root groups");
+    // Save root HOME and groups, then arm the restore guard before touching the
+    // process identity.
+    let _restore = RestoreRoot {
+        root_groups: getgroups().expect("failed to get root groups"),
+        root_home_opt: env::var_os("HOME"),
+    };
 
     // Switch to user HOME
     unsafe {
@@ -39,21 +67,7 @@ fn run_as_user<F: FnOnce() -> T, T>(user: &pwd::Passwd, f: F) -> Result<T, io::E
 
     let t = f();
 
-    // Restore root identity
-    seteuid(Uid::from_raw(0)).expect("failed to restore root uid");
-    setegid(Gid::from_raw(0)).expect("failed to restore root gid");
-    setgroups(&root_groups).expect("failed to restore root supplementary groups");
-
-    // Restore root HOME
-    match root_home_opt {
-        Some(root_home) => unsafe {
-            env::set_var("HOME", root_home);
-        },
-        None => unsafe {
-            env::remove_var("HOME");
-        },
-    }
-
+    // `_restore` is dropped here, restoring the root identity and HOME.
     Ok(t)
 }
 
@@ -64,6 +78,65 @@ enum GreeterError {
     ZBus(zbus::Error),
     Ron(String),
     RunAsUser(String),
+    UnknownUser(String),
+    InvalidXkbConfig(String),
+}
+
+// Reject an `XkbConfig` that would corrupt the user's keyboard setup or that
+// looks like abuse rather than a real layout selection. Called on the daemon
+// side because the only client that should reach `set_xkb_config` is the
+// greeter, but the D-Bus policy cannot enforce that, so the payload is treated
+// as untrusted.
+fn validate_xkb_config(xkb_config: &XkbConfig) -> Result<(), GreeterError> {
+    const MAX_FIELD_LEN: usize = 4096;
+    const MAX_LAYOUTS: usize = 64;
+
+    // An empty layout blanks the user's keyboard config, which makes cosmic-comp
+    // fall back to US and silently drops every configured layout. This is
+    // exactly the data loss of issue #258, so refuse to write it.
+    if xkb_config.layout.is_empty() {
+        return Err(GreeterError::InvalidXkbConfig("empty layout".to_string()));
+    }
+
+    // `layout` and `variant` are parallel comma-separated lists; a mismatch
+    // means the variants would bind to the wrong layouts.
+    let layout_count = xkb_config.layout.split(',').count();
+    let variant_count = xkb_config.variant.split(',').count();
+    if layout_count != variant_count {
+        return Err(GreeterError::InvalidXkbConfig(format!(
+            "layout/variant count mismatch ({layout_count} vs {variant_count})"
+        )));
+    }
+    if layout_count > MAX_LAYOUTS {
+        return Err(GreeterError::InvalidXkbConfig(format!(
+            "too many layouts ({layout_count})"
+        )));
+    }
+
+    // Bound every field so a caller cannot bloat the user's config file.
+    for (name, value) in [
+        ("rules", &xkb_config.rules),
+        ("model", &xkb_config.model),
+        ("layout", &xkb_config.layout),
+        ("variant", &xkb_config.variant),
+    ] {
+        if value.len() > MAX_FIELD_LEN {
+            return Err(GreeterError::InvalidXkbConfig(format!(
+                "{name} too long ({} bytes)",
+                value.len()
+            )));
+        }
+    }
+    if let Some(options) = &xkb_config.options
+        && options.len() > MAX_FIELD_LEN
+    {
+        return Err(GreeterError::InvalidXkbConfig(format!(
+            "options too long ({} bytes)",
+            options.len()
+        )));
+    }
+
+    Ok(())
 }
 
 struct GreeterProxy;
@@ -94,6 +167,77 @@ impl GreeterProxy {
 
         //TODO: is ron the best choice for passing around background data?
         ron::to_string(&user_datas).map_err(|err| GreeterError::Ron(err.to_string()))
+    }
+
+    // Persist a keyboard layout chosen in the greeter into the target user's
+    // cosmic-comp config, so the layout carries over into the started session.
+    //
+    // The greeter process runs as the unprivileged `cosmic-greeter` user and
+    // cannot write into another user's home directory; only this root daemon
+    // can, via `run_as_user`. Access to this interface is restricted to the
+    // `cosmic-greeter` group and root by the D-Bus policy, the same trust level
+    // as `get_user_data`.
+    //
+    // THREAT MODEL: this method has no notion of authentication. It trusts the
+    // D-Bus policy to limit callers to the `cosmic-greeter` group and root, and
+    // it trusts the greeter to only call it for a user who has just
+    // authenticated (see `App::persist_xkb_config_and_start`, gated on
+    // `Message::Login`).
+    // Any process running as `cosmic-greeter` can therefore rewrite any login
+    // user's keyboard layout without authenticating. That is an accepted,
+    // bounded risk: the write is confined to a single, validated `XkbConfig`
+    // value in one config key, written as the target user (never root), with no
+    // path or content under the caller's control beyond the layout itself, so
+    // the worst case is keyboard-layout tampering, not code execution or
+    // privilege escalation. We still validate the payload below rather than
+    // trusting the caller to have produced something sane.
+    fn set_xkb_config(
+        &mut self,
+        username: String,
+        xkb_config_ron: String,
+    ) -> Result<(), GreeterError> {
+        // Bound the payload before parsing so a caller cannot drive memory/CPU
+        // use with a giant RON string. A real xkb_config is well under 1 KiB.
+        const MAX_RON_LEN: usize = 64 * 1024;
+        if xkb_config_ron.len() > MAX_RON_LEN {
+            return Err(GreeterError::InvalidXkbConfig(format!(
+                "payload too large ({} bytes)",
+                xkb_config_ron.len()
+            )));
+        }
+
+        let xkb_config: XkbConfig =
+            ron::from_str(&xkb_config_ron).map_err(|err| GreeterError::Ron(err.to_string()))?;
+
+        // The greeter's own `build_xkb_config` already upholds these invariants,
+        // but this daemon must not trust the caller to have done so.
+        validate_xkb_config(&xkb_config)?;
+
+        // Only accept real login users (skips system accounts, nologin, etc.),
+        // and never trust the caller-supplied name without matching a passwd
+        // entry, which is what gates which files we write as root.
+        let user_filter = UserFilter::new();
+        let user = /* unsafe */ {
+            pwd::Passwd::iter()
+                .filter(|user| user_filter.filter(user))
+                .find(|user| user.name == username)
+        }
+        .ok_or_else(|| GreeterError::UnknownUser(format!("unknown user {:?}", username)))?;
+
+        //IMPORTANT: Assume the identity of the user so the config is written as
+        // that user and never as root.
+        run_as_user(&user, || {
+            let config =
+                cosmic_config::Config::new("com.system76.CosmicComp", CosmicCompConfig::VERSION)
+                    .map_err(|err| format!("failed to open cosmic-comp config: {}", err))?;
+            config
+                .set("xkb_config", xkb_config)
+                .map_err(|err| format!("failed to write xkb_config: {}", err))
+        })
+        .map_err(|err| GreeterError::RunAsUser(err.to_string()))?
+        .map_err(GreeterError::RunAsUser)?;
+
+        Ok(())
     }
 }
 

--- a/src/common.rs
+++ b/src/common.rs
@@ -7,7 +7,7 @@ use cosmic::iced::runtime::core::window::Id as SurfaceId;
 use cosmic::iced::{self, Rectangle, Size, Subscription};
 use cosmic::widget;
 use cosmic_config::{ConfigSet, CosmicConfigEntry};
-use cosmic_greeter_daemon::{BgSource, CosmicCompConfig, UserData};
+use cosmic_greeter_daemon::{BgSource, CosmicCompConfig, UserData, XkbConfig};
 use std::collections::HashMap;
 use std::sync::Arc;
 use wayland_client::protocol::wl_output::WlOutput;
@@ -60,6 +60,7 @@ pub enum Message {
     SessionLockEvent(SessionLockEvent),
     Tick,
     Tz(jiff::tz::TimeZone),
+    XkbConfigChanged(XkbConfig),
 }
 
 impl<M: From<Message> + Send + 'static> Common<M> {
@@ -195,52 +196,58 @@ impl<M: From<Message> + Send + 'static> Common<M> {
         }
     }
 
+    // From cosmic-applet-input-sources
+    pub fn refresh_active_layouts(&mut self, xkb_config: &XkbConfig) {
+        let Some(keyboard_layouts) = &self.layouts_opt else {
+            return;
+        };
+
+        self.active_layouts.clear();
+        let config_layouts = xkb_config.layout.split_terminator(',');
+        let config_variants = xkb_config
+            .variant
+            .split_terminator(',')
+            .chain(std::iter::repeat(""));
+        'outer: for (config_layout, config_variant) in config_layouts.zip(config_variants) {
+            for xkb_layout in keyboard_layouts.layouts() {
+                if config_layout != xkb_layout.name() {
+                    continue;
+                }
+                if config_variant.is_empty() {
+                    let active_layout = ActiveLayout {
+                        description: xkb_layout.description().to_owned(),
+                        layout: config_layout.to_owned(),
+                        variant: config_variant.to_owned(),
+                    };
+                    self.active_layouts.push(active_layout);
+                    continue 'outer;
+                }
+
+                let Some(xkb_variants) = xkb_layout.variants() else {
+                    continue;
+                };
+                for xkb_variant in xkb_variants {
+                    if config_variant != xkb_variant.name() {
+                        continue;
+                    }
+                    let active_layout = ActiveLayout {
+                        description: xkb_variant.description().to_owned(),
+                        layout: config_layout.to_owned(),
+                        variant: config_variant.to_owned(),
+                    };
+                    self.active_layouts.push(active_layout);
+                    continue 'outer;
+                }
+            }
+        }
+        tracing::info!("{:?}", self.active_layouts);
+    }
+
     pub fn update_user_data(&mut self, user_data: &UserData) {
         self.update_wallpapers(user_data);
 
-        // From cosmic-applet-input-sources
-        if let Some(keyboard_layouts) = &self.layouts_opt
-            && let Some(xkb_config) = &user_data.xkb_config_opt
-        {
-            self.active_layouts.clear();
-            let config_layouts = xkb_config.layout.split_terminator(',');
-            let config_variants = xkb_config
-                .variant
-                .split_terminator(',')
-                .chain(std::iter::repeat(""));
-            'outer: for (config_layout, config_variant) in config_layouts.zip(config_variants) {
-                for xkb_layout in keyboard_layouts.layouts() {
-                    if config_layout != xkb_layout.name() {
-                        continue;
-                    }
-                    if config_variant.is_empty() {
-                        let active_layout = ActiveLayout {
-                            description: xkb_layout.description().to_owned(),
-                            layout: config_layout.to_owned(),
-                            variant: config_variant.to_owned(),
-                        };
-                        self.active_layouts.push(active_layout);
-                        continue 'outer;
-                    }
-
-                    let Some(xkb_variants) = xkb_layout.variants() else {
-                        continue;
-                    };
-                    for xkb_variant in xkb_variants {
-                        if config_variant != xkb_variant.name() {
-                            continue;
-                        }
-                        let active_layout = ActiveLayout {
-                            description: xkb_variant.description().to_owned(),
-                            layout: config_layout.to_owned(),
-                            variant: config_variant.to_owned(),
-                        };
-                        self.active_layouts.push(active_layout);
-                        continue 'outer;
-                    }
-                }
-            }
-            tracing::info!("{:?}", self.active_layouts);
+        if let Some(xkb_config) = &user_data.xkb_config_opt {
+            self.refresh_active_layouts(xkb_config);
         }
     }
 
@@ -322,12 +329,33 @@ impl<M: From<Message> + Send + 'static> Common<M> {
             Message::Tz(tz) => {
                 self.time.set_tz(tz);
             }
+            Message::XkbConfigChanged(xkb_config) => {
+                self.refresh_active_layouts(&xkb_config);
+            }
         }
         Task::none()
     }
 
     pub fn subscription(&self) -> Subscription<Message> {
-        let mut subscriptions = Vec::with_capacity(3);
+        let mut subscriptions = Vec::with_capacity(4);
+
+        struct XkbConfigSubscription;
+        subscriptions.push(
+            cosmic_config::config_subscription(
+                std::any::TypeId::of::<XkbConfigSubscription>(),
+                "com.system76.CosmicComp".into(),
+                CosmicCompConfig::VERSION,
+            )
+            .map(|update: cosmic_config::Update<CosmicCompConfig>| {
+                if !update.errors.is_empty() {
+                    tracing::warn!(
+                        "errors loading com.system76.CosmicComp config: {:?}",
+                        update.errors
+                    );
+                }
+                Message::XkbConfigChanged(update.config.xkb_config)
+            }),
+        );
 
         subscriptions.push(event::listen_with(|event, status, id| match event {
             iced::Event::Keyboard(KeyEvent::KeyPressed {

--- a/src/common.rs
+++ b/src/common.rs
@@ -129,23 +129,42 @@ impl<M: From<Message> + Send + 'static> Common<M> {
         )
     }
 
-    pub fn set_xkb_config(&self, user_data: &UserData) {
-        if let Some(mut xkb_config) = user_data.xkb_config_opt.clone() {
-            xkb_config.layout = String::new();
-            xkb_config.variant = String::new();
-            for (i, layout) in self.active_layouts.iter().enumerate() {
-                if i > 0 {
-                    xkb_config.layout.push(',');
-                    xkb_config.variant.push(',');
-                }
-                xkb_config.layout.push_str(&layout.layout);
-                xkb_config.variant.push_str(&layout.variant);
+    /// Build the cosmic-comp `xkb_config` for the current `active_layouts`
+    /// ordering, based on `user_data`'s existing config.
+    ///
+    /// Returns `None` when there is nothing safe to write: an empty layout list
+    /// would blank out `layout` (and `variant`) in the user's cosmic-comp
+    /// config, dropping every configured keyboard layout and leaving them with
+    /// the default US layout. `active_layouts` is empty whenever the xkb-data
+    /// database failed to load (`layouts_opt == None`, so `refresh_active_layouts`
+    /// bails out early) or none of the configured layouts matched it.
+    pub fn build_xkb_config(&self, user_data: &UserData) -> Option<XkbConfig> {
+        if self.active_layouts.is_empty() {
+            tracing::warn!("refusing to write empty xkb_config layout list");
+            return None;
+        }
+        let mut xkb_config = user_data.xkb_config_opt.clone()?;
+        xkb_config.layout = String::new();
+        xkb_config.variant = String::new();
+        for (i, layout) in self.active_layouts.iter().enumerate() {
+            if i > 0 {
+                xkb_config.layout.push(',');
+                xkb_config.variant.push(',');
             }
-            if let Some(comp_config_handler) = &self.comp_config_handler {
-                match comp_config_handler.set("xkb_config", xkb_config) {
-                    Ok(()) => tracing::info!("updated cosmic-comp xkb_config"),
-                    Err(err) => tracing::error!("failed to update cosmic-comp xkb_config: {}", err),
-                }
+            xkb_config.layout.push_str(&layout.layout);
+            xkb_config.variant.push_str(&layout.variant);
+        }
+        Some(xkb_config)
+    }
+
+    pub fn set_xkb_config(&self, user_data: &UserData) {
+        let Some(xkb_config) = self.build_xkb_config(user_data) else {
+            return;
+        };
+        if let Some(comp_config_handler) = &self.comp_config_handler {
+            match comp_config_handler.set("xkb_config", xkb_config) {
+                Ok(()) => tracing::info!("updated cosmic-comp xkb_config"),
+                Err(err) => tracing::error!("failed to update cosmic-comp xkb_config: {}", err),
             }
         }
     }
@@ -239,6 +258,16 @@ impl<M: From<Message> + Send + 'static> Common<M> {
                     continue 'outer;
                 }
             }
+
+            // The configured layout isn't present in the xkb-data database.
+            // Keep it anyway (using the raw code as its description) so it is
+            // still shown and, crucially, survives the next `set_xkb_config`
+            // write instead of being silently removed from the user's config.
+            self.active_layouts.push(ActiveLayout {
+                description: config_layout.to_owned(),
+                layout: config_layout.to_owned(),
+                variant: config_variant.to_owned(),
+            });
         }
         tracing::info!("{:?}", self.active_layouts);
     }

--- a/src/greeter.rs
+++ b/src/greeter.rs
@@ -63,6 +63,23 @@ static USERNAME_ID: LazyLock<iced::id::Id> = LazyLock::new(|| iced::id::Id::new(
 )]
 trait Greeter {
     async fn get_user_data(&self) -> Result<String, zbus::Error>;
+    async fn set_xkb_config(
+        &self,
+        username: &str,
+        xkb_config_ron: &str,
+    ) -> Result<(), zbus::Error>;
+}
+
+// Ask the root daemon to persist a greeter-selected keyboard layout into the
+// target user's cosmic-comp config, so it carries over into their session.
+async fn set_user_xkb_config_dbus(
+    username: String,
+    xkb_config_ron: String,
+) -> Result<(), Box<dyn Error>> {
+    let connection = Connection::system().await?;
+    let proxy = GreeterProxy::new(&connection).await?;
+    proxy.set_xkb_config(&username, &xkb_config_ron).await?;
+    Ok(())
 }
 
 async fn user_data_dbus() -> Result<Vec<UserData>, Box<dyn Error>> {
@@ -421,6 +438,12 @@ pub struct App {
 
     accessibility: Accessibility,
     authenticating: bool,
+    /// `data_idx` of the user whose stored `xkb_config` was last loaded into
+    /// `active_layouts`. Used to avoid clobbering a greeter-selected layout when
+    /// `update_user_data` runs again for the *same* user (e.g. on the socket
+    /// reconnect that follows a failed login), while still loading a different
+    /// user's layout when the selection actually changes.
+    xkb_loaded_user: Option<usize>,
 }
 
 #[derive(Default)]
@@ -1025,7 +1048,70 @@ impl App {
             None => return,
         };
 
+        // Apply the layout to the greeter's own compositor so the password
+        // field types in the selected layout. The choice is persisted into the
+        // user's own config only after authentication succeeds; see
+        // `persist_xkb_config`.
         self.common.set_xkb_config(user_data);
+    }
+
+    /// Persist the greeter-selected layout into the authenticated user's config
+    /// via the root daemon, then start the session, so the choice carries over
+    /// into the started session instead of reverting to whatever was last saved.
+    /// The greeter cannot write the user's home directory itself.
+    ///
+    /// `StartSession` is sent only after the daemon call resolves: greetd tears
+    /// down this greeter process as soon as the session starts, so sending it
+    /// first would kill the persist future mid-call and silently drop the layout
+    /// (issue #258). The call is bounded by a timeout so an unresponsive daemon
+    /// cannot block login; on persist failure or timeout the session still
+    /// starts (with the user's previously saved layout).
+    ///
+    /// This must only be called after authentication has succeeded (i.e. from
+    /// `Message::Login`): otherwise an unauthenticated person at the greeter
+    /// could rewrite any listed user's saved `xkb_config`.
+    fn persist_xkb_config_and_start(&self, cmd: Vec<String>, env: Vec<String>) -> Task<Message> {
+        // Build the payload to persist. This may be None (no user_data, empty
+        // active_layouts, or serialization failure), in which case we persist
+        // nothing but must still start the session.
+        let payload = self
+            .selected_username
+            .data_idx
+            .and_then(|i| self.flags.user_datas.get(i))
+            .and_then(|user_data| {
+                let xkb_config = self.common.build_xkb_config(user_data)?;
+                match ron::to_string(&xkb_config) {
+                    Ok(ron) => Some((user_data.name.clone(), ron)),
+                    Err(err) => {
+                        tracing::error!("failed to serialize xkb_config: {}", err);
+                        None
+                    }
+                }
+            });
+
+        let sender = self.greetd_sender.clone();
+
+        cosmic::Task::future(async move {
+            if let Some((username, xkb_config_ron)) = payload {
+                let call = set_user_xkb_config_dbus(username, xkb_config_ron);
+                match tokio::time::timeout(std::time::Duration::from_secs(3), call).await {
+                    Ok(Ok(())) => {}
+                    Ok(Err(err)) => {
+                        tracing::error!("failed to persist user xkb_config via daemon: {}", err)
+                    }
+                    Err(_) => tracing::error!(
+                        "timed out persisting user xkb_config via daemon; starting session anyway"
+                    ),
+                }
+            }
+
+            // Start the session only after the persist attempt has resolved, so
+            // greetd does not tear down this greeter process mid-call (#258).
+            if let Some(sender) = sender {
+                _ = sender.send(Request::StartSession { cmd, env }).await;
+            }
+        })
+        .discard()
     }
 
     fn update_user_data(&mut self) -> Task<Message> {
@@ -1040,10 +1126,21 @@ impl App {
             }
         };
 
-        self.common.update_user_data(user_data);
+        // Only (re)load the user's stored keyboard layout when the selected
+        // user has changed. This path also runs on the greetd socket reconnect
+        // that follows a failed login; refreshing there would discard a layout
+        // the user picked in the greeter and switch cosmic-comp back to the
+        // stored config mid-login (issue #258).
+        let selected_idx = self.selected_username.data_idx;
+        if self.xkb_loaded_user != selected_idx {
+            self.xkb_loaded_user = selected_idx;
+            self.common.update_user_data(user_data);
 
-        // Ensure that user's xkb config is used
-        self.common.set_xkb_config(user_data);
+            // Ensure that user's xkb config is used
+            self.common.set_xkb_config(user_data);
+        } else {
+            self.common.update_wallpapers(user_data);
+        }
 
         if let Some(builder) = &user_data.theme_builder_opt {
             self.theme_builder = builder.clone();
@@ -1165,6 +1262,7 @@ impl cosmic::Application for App {
             randr_list: None,
             surface_id_pairs: Vec::new(),
             authenticating: false,
+            xkb_loaded_user: None,
         };
         (app, Task::batch(tasks))
     }
@@ -1480,8 +1578,20 @@ impl cosmic::Application for App {
 
                 match self.flags.sessions.get(&self.selected_session).cloned() {
                     Some((cmd, env)) => {
-                        self.send_request(Request::StartSession { cmd, env });
-                        return self.update(Message::ConfigUpdateUser);
+                        // Authentication has succeeded, so it is now safe to
+                        // persist the greeter-selected layout into this user's
+                        // own config. The persist call must finish *before*
+                        // StartSession: greetd tears down this greeter process
+                        // as soon as the session starts, which would kill an
+                        // in-flight async persist future and silently drop the
+                        // layout (issue #258). So StartSession is sent from
+                        // inside the persist future, only after the daemon call
+                        // resolves.
+                        let persist_and_start = self.persist_xkb_config_and_start(cmd, env);
+                        return Task::batch([
+                            persist_and_start,
+                            self.update(Message::ConfigUpdateUser),
+                        ]);
                     }
                     None => todo!("session {:?} not found", self.selected_session),
                 }

--- a/src/greeter.rs
+++ b/src/greeter.rs
@@ -372,6 +372,8 @@ pub enum Message {
         randr: Arc<Result<List, cosmic_randr_shell::Error>>,
     },
     Heartbeat,
+    /// Cycle to the next keyboard layout (cosmic-comp `Super+Space` shortcut).
+    InputSourceSwitch,
     KeyboardLayout(usize),
     Login,
     Reconnect,
@@ -1533,6 +1535,14 @@ impl cosmic::Application for App {
                     self.dropdown_opt = Some(dropdown);
                 }
             }
+            Message::InputSourceSwitch => {
+                // Cycle to the next layout, matching cosmic-settings-daemon's
+                // behaviour (move the active layout to the back of the list).
+                if self.common.active_layouts.len() > 1 {
+                    self.common.active_layouts.rotate_left(1);
+                    self.set_xkb_config();
+                }
+            }
             Message::KeyboardLayout(layout_i) => {
                 if layout_i < self.common.active_layouts.len() {
                     self.common.active_layouts.swap(0, layout_i);
@@ -1844,6 +1854,7 @@ impl cosmic::Application for App {
     fn subscription(&self) -> Subscription<Self::Message> {
         Subscription::batch([
             self.common.subscription().map(Message::from),
+            crate::input_source::subscription().map(|()| Message::InputSourceSwitch),
             ipc::subscription(),
             wayland::a11y_subscription().map(Message::WaylandUpdate),
             listen_with(|event, _status, id| match event {

--- a/src/input_source.rs
+++ b/src/input_source.rs
@@ -1,0 +1,75 @@
+// Copyright 2026 System76 <info@system76.com>
+// SPDX-License-Identifier: GPL-3.0-only
+
+//! Minimal `com.system76.CosmicSettingsDaemon` service for the greeter session.
+//!
+//! `Super+Space` (switch keyboard layout) is handled by cosmic-comp, which
+//! reacts to the shortcut by spawning the configured `system_actions` command:
+//!
+//! ```text
+//! busctl --user call com.system76.CosmicSettingsDaemon \
+//!     /com/system76/CosmicSettingsDaemon \
+//!     com.system76.CosmicSettingsDaemon InputSourceSwitch
+//! ```
+//!
+//! In a normal user session that call is serviced by cosmic-settings-daemon,
+//! which rotates the active keyboard layout. cosmic-settings-daemon does not run
+//! inside the greeter session, so the call has no receiver and the shortcut does
+//! nothing. We provide the `InputSourceSwitch` method ourselves and let the
+//! greeter perform the same layout rotation it does for the dropdown.
+
+use cosmic::iced::futures::SinkExt;
+use cosmic::iced::futures::channel::mpsc;
+use cosmic::iced::{Subscription, stream};
+use std::any::TypeId;
+use std::future::pending;
+use zbus::connection::Builder;
+
+/// D-Bus object exposing the subset of `com.system76.CosmicSettingsDaemon` that
+/// cosmic-comp's `Super+Space` shortcut relies on.
+struct InputSource {
+    msg_tx: mpsc::Sender<()>,
+}
+
+#[zbus::interface(name = "com.system76.CosmicSettingsDaemon")]
+impl InputSource {
+    /// Cycle to the next keyboard layout. Forwarded to the greeter's update
+    /// loop, which rotates the active layouts and applies the new xkb config.
+    async fn input_source_switch(&self) {
+        if let Err(err) = self.msg_tx.clone().send(()).await {
+            tracing::warn!("failed to forward InputSourceSwitch: {}", err);
+        }
+    }
+}
+
+async fn serve(msg_tx: mpsc::Sender<()>) -> zbus::Result<()> {
+    let _conn = Builder::session()?
+        .name("com.system76.CosmicSettingsDaemon")?
+        .serve_at("/com/system76/CosmicSettingsDaemon", InputSource { msg_tx })?
+        .build()
+        .await?;
+
+    // Hold the connection (and therefore the bus name) for the greeter's
+    // lifetime so the shortcut keeps working.
+    pending::<()>().await;
+    Ok(())
+}
+
+/// Serve a minimal `com.system76.CosmicSettingsDaemon` on the session bus so the
+/// `Super+Space` keyboard-layout shortcut works inside the greeter. Each
+/// `InputSourceSwitch` call yields a unit value.
+pub fn subscription() -> Subscription<()> {
+    struct InputSourceSubscription;
+
+    Subscription::run_with(TypeId::of::<InputSourceSubscription>(), |_| {
+        stream::channel(16, |msg_tx| async move {
+            if let Err(err) = serve(msg_tx).await {
+                tracing::warn!("input source switch service error: {}", err);
+            }
+
+            // Don't respawn the service on failure (e.g. the name is already
+            // owned by a real cosmic-settings-daemon).
+            pending::<()>().await
+        })
+    })
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,8 @@ mod wayland;
 
 mod common;
 
+mod input_source;
+
 mod localize;
 
 #[cfg(feature = "logind")]


### PR DESCRIPTION
closes #258

depends on #477

User changes made to the selected keyboard layout in greeter on a fresh boot now persist to the new user session after login. This is very, very convenient for people frequently switching between keyboard layouts.

I tried my best but I advise the engineers to take a really close look at these security sensitive code changes. I approached this with zero trust principles in mind and added (hopefully) easy to understand comments as developer documentation on why things are implemented the way they are. Since I am not a native English speaker, I used an LLM to help me rephrase my code comments to be as compact and precise as possible. Of course, I have done manual proofreading of the final code comments myself, twice.


- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

