### PR TITLE
feature/lock screen layout indicator

### DIFF
--- a/src/greeter.rs
+++ b/src/greeter.rs
@@ -582,12 +582,31 @@ impl App {
                 }
             };
 
+
+            let layout_code = self
+                .common
+                .active_layouts
+                .get(self.common.current_keyboard_layout)
+                .map(|l| l.description.as_str())
+                .unwrap_or("")
+                .to_uppercase();
+            
+            let space_width = if !layout_code.is_empty() { 4.0 } else { 0.0 };
+            
+            let button_content = widget::row::with_children(vec![
+                widget::icon::from_name("input-keyboard-symbolic").into(),
+                widget::space::horizontal().width(space_width).into(),
+                widget::text(layout_code).into(),
+            ])
+            .align_y(Alignment::Center);
+            
             let mut input_button = widget::popover(
-                widget::button::custom(widget::icon::from_name("input-keyboard-symbolic"))
-                    .padding(12.0)
+                widget::button::custom(button_content)
+                    .padding([10.0, 14.0])
                     .on_press(Message::DropdownToggle(Dropdown::Keyboard)),
             )
             .position(widget::popover::Position::Bottom);
+
             if matches!(self.dropdown_opt, Some(Dropdown::Keyboard)) {
                 let mut items = Vec::with_capacity(self.common.active_layouts.len());
                 for (i, layout) in self.common.active_layouts.iter().enumerate() {
@@ -599,7 +618,6 @@ impl App {
                 }
                 input_button = input_button.popup(dropdown_menu(items));
             }
-
             let mut user_button = widget::popover(
                 widget::button::custom(widget::icon::from_name("system-users-symbolic"))
                     .padding(12.0)

--- a/src/greeter.rs
+++ b/src/greeter.rs
@@ -579,12 +579,31 @@ impl App {
                 }
             };
 
+
+            let layout_code = self
+                .common
+                .active_layouts
+                .get(self.common.current_keyboard_layout)
+                .map(|l| l.description.as_str())
+                .unwrap_or("")
+                .to_uppercase();
+            
+            let space_width = if !layout_code.is_empty() { 4.0 } else { 0.0 };
+            
+            let button_content = widget::row::with_children(vec![
+                widget::icon::from_name("input-keyboard-symbolic").into(),
+                widget::space::horizontal().width(space_width).into(),
+                widget::text(layout_code).into(),
+            ])
+            .align_y(Alignment::Center);
+            
             let mut input_button = widget::popover(
-                widget::button::custom(widget::icon::from_name("input-keyboard-symbolic"))
-                    .padding(12.0)
+                widget::button::custom(button_content)
+                    .padding([10.0, 14.0])
                     .on_press(Message::DropdownToggle(Dropdown::Keyboard)),
             )
             .position(widget::popover::Position::Bottom);
+
             if matches!(self.dropdown_opt, Some(Dropdown::Keyboard)) {
                 let mut items = Vec::with_capacity(self.common.active_layouts.len());
                 for (i, layout) in self.common.active_layouts.iter().enumerate() {
@@ -596,7 +615,6 @@ impl App {
                 }
                 input_button = input_button.popup(dropdown_menu(items));
             }
-
             let mut user_button = widget::popover(
                 widget::button::custom(widget::icon::from_name("system-users-symbolic"))
                     .padding(12.0)

--- a/src/greeter.rs
+++ b/src/greeter.rs
@@ -589,9 +589,8 @@ impl App {
                 .map(|l| l.layout.as_str())
                 .unwrap_or("");
 
-            let mut button_widgets: Vec<Element<_>> = vec![
-                widget::icon::from_name("input-keyboard-symbolic").into()
-            ];
+            let mut button_row =
+                widget::row::with_capacity(3).spacing(6.0).align_y(Alignment::Center).push(widget::icon::from_name("input-keyboard-symbolic").into());
 
             if !layout_code.is_empty() {
                 button_widgets.push(widget::space::horizontal().width(4.0).into());

--- a/src/greeter.rs
+++ b/src/greeter.rs
@@ -579,42 +579,50 @@ impl App {
                 }
             };
 
-
             let layout_code = self
                 .common
                 .active_layouts
                 .get(self.common.current_keyboard_layout)
-                .map(|l| l.description.as_str())
-                .unwrap_or("")
-                .to_uppercase();
-            
-            let space_width = if !layout_code.is_empty() { 4.0 } else { 0.0 };
-            
-            let button_content = widget::row::with_children(vec![
-                widget::icon::from_name("input-keyboard-symbolic").into(),
-                widget::space::horizontal().width(space_width).into(),
-                widget::text(layout_code).into(),
-            ])
-            .align_y(Alignment::Center);
-            
-            let mut input_button = widget::popover(
-                widget::button::custom(button_content)
-                    .padding([10.0, 14.0])
-                    .on_press(Message::DropdownToggle(Dropdown::Keyboard)),
-            )
-            .position(widget::popover::Position::Bottom);
+                .map(|l| l.layout.as_str())
+                .unwrap_or("");
 
-            if matches!(self.dropdown_opt, Some(Dropdown::Keyboard)) {
-                let mut items = Vec::with_capacity(self.common.active_layouts.len());
-                for (i, layout) in self.common.active_layouts.iter().enumerate() {
-                    items.push(menu_checklist(
-                        &layout.description,
-                        i == self.common.current_keyboard_layout,
-                        Message::KeyboardLayout(i),
-                    ));
-                }
-                input_button = input_button.popup(dropdown_menu(items));
+            let mut button_widgets: Vec<Element<_>> = vec![
+                widget::icon::from_name("input-keyboard-symbolic").into()
+            ];
+
+            if !layout_code.is_empty() {
+                button_widgets.push(widget::space::horizontal().width(4.0).into());
+                button_widgets.push(widget::text(layout_code.to_uppercase()).into());
             }
+
+            let button_content = widget::row::with_children(button_widgets)
+                .align_y(Alignment::Center);
+
+            let button = widget::button::custom(button_content)
+                .padding(if layout_code.is_empty() {[12.0, 12.0]} else {[10.0, 14.0]})
+                .on_press(Message::DropdownToggle(Dropdown::Keyboard));
+
+            let input_button = if matches!(self.dropdown_opt, Some(Dropdown::Keyboard)) {
+                let items = self
+                    .common
+                    .active_layouts
+                    .iter()
+                    .enumerate()
+                    .map(|(i, layout)| {
+                        menu_checklist(
+                            &layout.description,
+                            i == self.common.current_keyboard_layout,
+                            Message::KeyboardLayout(i),
+                        )
+                    })
+                    .collect();
+
+                widget::popover(button)
+                    .position(widget::popover::Position::Bottom)
+                    .popup(dropdown_menu(items))
+            } else {
+                widget::popover(button).position(widget::popover::Position::Bottom)
+            };
             let mut user_button = widget::popover(
                 widget::button::custom(widget::icon::from_name("system-users-symbolic"))
                     .padding(12.0)

--- a/src/greeter.rs
+++ b/src/greeter.rs
@@ -582,42 +582,50 @@ impl App {
                 }
             };
 
-
             let layout_code = self
                 .common
                 .active_layouts
                 .get(self.common.current_keyboard_layout)
-                .map(|l| l.description.as_str())
-                .unwrap_or("")
-                .to_uppercase();
-            
-            let space_width = if !layout_code.is_empty() { 4.0 } else { 0.0 };
-            
-            let button_content = widget::row::with_children(vec![
-                widget::icon::from_name("input-keyboard-symbolic").into(),
-                widget::space::horizontal().width(space_width).into(),
-                widget::text(layout_code).into(),
-            ])
-            .align_y(Alignment::Center);
-            
-            let mut input_button = widget::popover(
-                widget::button::custom(button_content)
-                    .padding([10.0, 14.0])
-                    .on_press(Message::DropdownToggle(Dropdown::Keyboard)),
-            )
-            .position(widget::popover::Position::Bottom);
+                .map(|l| l.layout.as_str())
+                .unwrap_or("");
 
-            if matches!(self.dropdown_opt, Some(Dropdown::Keyboard)) {
-                let mut items = Vec::with_capacity(self.common.active_layouts.len());
-                for (i, layout) in self.common.active_layouts.iter().enumerate() {
-                    items.push(menu_checklist(
-                        &layout.description,
-                        i == self.common.current_keyboard_layout,
-                        Message::KeyboardLayout(i),
-                    ));
-                }
-                input_button = input_button.popup(dropdown_menu(items));
+            let mut button_widgets: Vec<Element<_>> = vec![
+                widget::icon::from_name("input-keyboard-symbolic").into()
+            ];
+
+            if !layout_code.is_empty() {
+                button_widgets.push(widget::space::horizontal().width(4.0).into());
+                button_widgets.push(widget::text(layout_code.to_uppercase()).into());
             }
+
+            let button_content = widget::row::with_children(button_widgets)
+                .align_y(Alignment::Center);
+
+            let button = widget::button::custom(button_content)
+                .padding(if layout_code.is_empty() {[12.0, 12.0]} else {[10.0, 14.0]})
+                .on_press(Message::DropdownToggle(Dropdown::Keyboard));
+
+            let input_button = if matches!(self.dropdown_opt, Some(Dropdown::Keyboard)) {
+                let items = self
+                    .common
+                    .active_layouts
+                    .iter()
+                    .enumerate()
+                    .map(|(i, layout)| {
+                        menu_checklist(
+                            &layout.description,
+                            i == self.common.current_keyboard_layout,
+                            Message::KeyboardLayout(i),
+                        )
+                    })
+                    .collect();
+
+                widget::popover(button)
+                    .position(widget::popover::Position::Bottom)
+                    .popup(dropdown_menu(items))
+            } else {
+                widget::popover(button).position(widget::popover::Position::Bottom)
+            };
             let mut user_button = widget::popover(
                 widget::button::custom(widget::icon::from_name("system-users-symbolic"))
                     .padding(12.0)

--- a/src/greeter.rs
+++ b/src/greeter.rs
@@ -582,26 +582,35 @@ impl App {
                 }
             };
 
-            let layout_code = self
+            let current_layout_opt = self
                 .common
                 .active_layouts
-                .get(self.common.current_keyboard_layout)
-                .map(|l| l.layout.as_str())
-                .unwrap_or("");
+                .get(self.common.current_keyboard_layout);
 
             let mut button_row =
                 widget::row::with_capacity(3).spacing(6.0).align_y(Alignment::Center).push(widget::icon::from_name("input-keyboard-symbolic").into());
 
-            if !layout_code.is_empty() {
-                button_widgets.push(widget::space::horizontal().width(4.0).into());
-                button_widgets.push(widget::text(layout_code.to_uppercase()).into());
+            if let Some(active_layout) = current_layout_opt {
+                if !active_layout.layout.is_empty() {
+                    let label = if active_layout.variant.is_empty() {
+                        active_layout.layout.to_uppercase()
+                    } else {
+                        format!(
+                            "{} {}",
+                            active_layout.layout.to_uppercase(),
+                            active_layout.variant.to_uppercase()
+                        )
+                    };
+                    button_row = button_row.push(widget::text(label));
+                }
             }
 
-            let button_content = widget::row::with_children(button_widgets)
-                .align_y(Alignment::Center);
-
-            let button = widget::button::custom(button_content)
-                .padding(if layout_code.is_empty() {[12.0, 12.0]} else {[10.0, 14.0]})
+            let button = widget::button::custom(button_row)
+                .padding(if current_layout_opt.is_some() {
+                    [10.0, 14.0]
+                } else {
+                    [12.0, 12.0]
+                })
                 .on_press(Message::DropdownToggle(Dropdown::Keyboard));
 
             let input_button = if matches!(self.dropdown_opt, Some(Dropdown::Keyboard)) {


### PR DESCRIPTION
- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

[Kooha-2026-07-30-22-37-27.webm](https://github.com/user-attachments/assets/f8ca8362-5848-4740-b874-f861cf67a688)

I have two languages on my system and when entering password, I am always wondering what  the active keyboard layout is. So I decided to add a label showing selected language.  I have to say that AI was used for searching the optimal solutions and best practices.
Also I've experienced this bug where the language popup was empty and for video demo i had to mock data like this (did not commit mocking):
```rust
  let mock_layouts = vec![
                common::ActiveLayout { layout: "us".to_string(), description: "English (US)".to_string(), variant: "".to_string() },
                common::ActiveLayout { layout: "ru".to_string(), description: "Russian".to_string() , variant: "".to_string()},
            ];
```
So I can't 100% say that this is tested as i could not make `just mock` get the languages.  I also noticed that in `locker.rs` the same code is being used as in `greeter.rs`, I thought that this is out of scope of this pr, as there is no logic there, but I can refine that as well 