### PR TITLE
i18n(is): complete Icelandic translation to 100% parity

### DIFF
--- a/i18n/is/cosmic_greeter.ftl
+++ b/i18n/is/cosmic_greeter.ftl
@@ -27,3 +27,10 @@ shutdown-timeout =
        *[other] { $seconds } sekúndur.
     }
 user = Notandi
+
+authenticating = Auðkenni...
+auth-error-default = Auðkenning mistókst. Reyndu aftur.
+auth-error-credentials = Rangt lykilorð. Athugaðu lyklaborðsskipanina og reyndu aftur.
+auth-error-denied = Aðgangi hafnað.
+auth-error-maxtries = Of margar misheppnaðar auðkenningartilraunir.
+auth-error-account = Reikningurinn er ekki tiltækur eða óvirkur.


### PR DESCRIPTION
Completes the Icelandic (`is`) localization to 100% key parity with `en`.

Terminology grounded in Íðorðabankinn (the TOLVA computing dictionary, Árnastofnun) and made consistent with COSMIC's existing Icelandic translations. Fluent placeables, selector keys, attributes, and proper nouns are preserved; only human-readable text was translated. Validated with `fluent.syntax` (no Junk) and full en/is key-parity checks.