### PR TITLE
fix: ignore empty password

### DIFF
--- a/src/locker.rs
+++ b/src/locker.rs
@@ -1059,16 +1059,18 @@ impl cosmic::Application for App {
                 }
             }
             Message::Submit(value) => {
-                self.common.error_opt = None;
-                self.authenticating = true;
-                match self.value_tx_opt.take() {
-                    Some(value_tx) => {
-                        return cosmic::task::future(async move {
-                            value_tx.send(value).await.unwrap();
-                            Message::Channel(value_tx)
-                        });
+                if !value.is_empty() {
+                    self.common.error_opt = None;
+                    self.authenticating = true;
+                    match self.value_tx_opt.take() {
+                        Some(value_tx) => {
+                            return cosmic::task::future(async move {
+                                value_tx.send(value).await.unwrap();
+                                Message::Channel(value_tx)
+                            });
+                        }
+                        None => tracing::warn!("tried to submit when value_tx_opt not set"),
                     }
-                    None => tracing::warn!("tried to submit when value_tx_opt not set"),
                 }
             }
             Message::Suspend => {

--- a/src/locker.rs
+++ b/src/locker.rs
@@ -1059,18 +1059,19 @@ impl cosmic::Application for App {
                 }
             }
             Message::Submit(value) => {
-                if !value.is_empty() {
-                    self.common.error_opt = None;
-                    self.authenticating = true;
-                    match self.value_tx_opt.take() {
-                        Some(value_tx) => {
-                            return cosmic::task::future(async move {
-                                value_tx.send(value).await.unwrap();
-                                Message::Channel(value_tx)
-                            });
-                        }
-                        None => tracing::warn!("tried to submit when value_tx_opt not set"),
+                if value.is_empty() {
+                    return Task::none();
+                }
+                self.common.error_opt = None;
+                self.authenticating = true;
+                match self.value_tx_opt.take() {
+                    Some(value_tx) => {
+                        return cosmic::task::future(async move {
+                            value_tx.send(value).await.unwrap();
+                            Message::Channel(value_tx)
+                        });
                     }
+                    None => tracing::warn!("tried to submit when value_tx_opt not set"),
                 }
             }
             Message::Suspend => {


### PR DESCRIPTION
When the screen is locked, pressing `<Enter>` without any password causes cosmic-greeter to spin forever in a loop.

Prevent this by checking that the password field is non-empty before submitting the authentication request.

---
Note there is similar logic in greeter.rs which may also need to be fixed. But I am not sure yet how to trigger that code.

No AI was used for this PR. All mistakes are my own.

- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

