### PR TITLE
fix(greeter): do not cancel the session on a non-fatal PAM error message

### DIFF
--- a/src/greeter.rs
+++ b/src/greeter.rs
@@ -363,6 +363,9 @@ pub enum Message {
     Common(common::Message),
     OutputEvent(OutputEvent, WlOutput),
     Auth(Option<String>),
+    /// Non-fatal error message from PAM (`PAM_ERROR_MSG`), reported by greetd as an auth
+    /// message of type `Error`. Unlike [`Message::Error`] the conversation stays alive.
+    AuthError(String),
     ConfigUpdateUser,
     DialogCancel,
     DialogConfirm,
@@ -1489,6 +1492,13 @@ impl cosmic::Application for App {
                 self.common.error_opt = None;
                 self.authenticating = true;
                 self.send_request(Request::PostAuthMessageResponse { response });
+            }
+            Message::AuthError(error) => {
+                // The conversation continues, so acknowledge like any other
+                // non-interactive auth message rather than cancelling the session.
+                self.common.error_opt = Some(error);
+                self.authenticating = false;
+                self.send_request(Request::PostAuthMessageResponse { response: None });
             }
             Message::Login => {
                 self.common.prompt_opt = None;

--- a/src/greeter/ipc.rs
+++ b/src/greeter/ipc.rs
@@ -115,7 +115,8 @@ pub fn subscription() -> Subscription<Message> {
                                                 .await;
                                         }
                                         greetd_ipc::AuthMessageType::Error => {
-                                            _ = sender.send(Message::Error(auth_message)).await;
+                                            // PAM_ERROR_MSG: a failed attempt, not a dead session.
+                                            _ = sender.send(Message::AuthError(auth_message)).await;
                                         }
                                     },
                                     greetd_ipc::Response::Error {


### PR DESCRIPTION
One failed fingerprint press at the login screen ends the PAM conversation, and
the fingerprint reader stays unusable until the greeter restarts.

This is a different cause from the two open reports that share the symptom, and
neither is fixed by this change:

* **#173** (and #470, closed as its duplicate) is the lock screen after suspend —
  `locker.rs`, a conversation that went stale while the machine slept.
* **#507** is a startup ordering race — the greeter begins a PAM conversation
  before fprintd is ready, and greetd crashes. It needs no user interaction.
* **This** needs exactly one failed press and no suspend: the greeter cancels its
  own session because it treats a PAM message *about the attempt* as fatal.

## Cause

`AuthMessageType::Error` is `PAM_ERROR_MSG` — a message about the current
attempt, not the end of the conversation. `pam_fprintd` sends
`Failed to match fingerprint` that way and keeps going until `max-tries` is
reached. `src/greeter/ipc.rs` turned it into `Message::Error`, which cancels the
greetd session.

The session created right afterwards then loses the race for the fingerprint
reader: its PAM worker calls fprintd's `Claim` 14 ms after the cancel, while the
previous worker still holds it, so the claim is denied and no fingerprint prompt
ever appears again.

Delaying the new session does not help. The previous worker keeps the claim until
it next tries to talk to the greeter, which can be arbitrarily far away — in one
measurement 7.76 s, and it was the *correct* finger that finally woke it, which
the dead worker then consumed instead of logging in.

## Change

The message is routed to its own `Message::AuthError`, which shows the text and
acknowledges it with `PostAuthMessageResponse { response: None }` — the same
handling the `Info` arm already uses, as the greetd protocol requires for a
non-interactive message. `Message::Error` and the `Response::Error` path are
unchanged, so a genuinely failed authentication still cancels the session.

## Testing

ThinkPad T490, Synaptics `06cb:00bd`, `pam_fprintd max-tries=5`, Pop!_OS 24.04.
Four greeter sessions: three after logging out, one after a cold boot.

* failed press, then correct press (logout path) → the prompt comes back by
  itself after 111 ms and the correct finger logs in. Before the change: reader
  dead, password only.
* five failed presses, once after logout and once after a cold boot →
  `max-tries` is exhausted on a single device claim, PAM falls through to
  `pam_unix`, and the password field appears on its own.
* wrong password → still cancels, via `Response::Error`; the new session gets the
  claim and fingerprint login works again.
* successful press on the first try → unchanged.

In all four sessions a single greetd worker served the whole login, and there was
no `Device was already claimed` in the journal.

Measured on one sensor model; I cannot speak for other readers.

- [x] I have disclosed use of any AI generated code in my commit messages.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.
