### PR TITLE
fix: ignore empty responses on the login screen

### DIFF
--- a/src/greeter.rs
+++ b/src/greeter.rs
@@ -1486,6 +1486,9 @@ impl cosmic::Application for App {
                 }
             }
             Message::Auth(response) => {
+                if response.as_deref() == Some("") {
+                    return Task::none();
+                }
                 self.common.error_opt = None;
                 self.authenticating = true;
                 self.send_request(Request::PostAuthMessageResponse { response });


### PR DESCRIPTION
Companion to #509, which added the same guard to the lock screen; rfs613 asked whether `greeter.rs` needs one too. It does, and the mock in `examples/server.rs` triggers it — inside a nested compositor, as the greeter takes an overlay layer with exclusive keyboard input.

**Cause**

`Message::Auth` is built in exactly one place, `.on_submit(|v| Message::Auth(Some(v)))`, and is unguarded. `Info` messages are acknowledged separately with `response: None` and never reach it, so `Some("")` can only be <kbd>Enter</kbd> on an empty field. It is sent, rejected, and greetd tears the session down; the greeter reconnects. Each press on `f64e2d8` costs that round trip:

```
10:03:22.290  PostAuthMessageResponse { response: Some("") }
10:03:23.291  CancelSession
10:03:23.294  CreateSession { username: "chris" }
```

**Testing**

Same mock, build of `f64e2d8` with only this patch:

```
18:47:05.762  PostAuthMessageResponse { response: Some("x") }
18:47:06.757  CancelSession
18:47:06.758  CreateSession { username: "chris" }
      <- three Enter presses on the empty field, nothing sent for 76 s ->
18:48:23.174  PostAuthMessageResponse { response: Some("password") }
18:48:23.178  StartSession { ... }
```

Wrong-password and success paths unchanged. The two logging rounds bracket the silent one deliberately, so the silence means the guard held rather than that the keystrokes went elsewhere.

- [x] I have disclosed use of any AI generated code in my commit messages.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.
