### PR TITLE
fix(greeter): show a second sequential auth prompt instead of hanging

### DIFF
--- a/src/greeter.rs
+++ b/src/greeter.rs
@@ -1190,6 +1190,19 @@ impl cosmic::Application for App {
                     self.send_request(Request::PostAuthMessageResponse { response: None });
                 }
 
+                // A second interactive prompt (e.g. a PAM module stacked ahead of the
+                // real password check asks its own question first, then declines and
+                // falls through to a genuine password request) must clear
+                // `authenticating`, or the `!self.authenticating` check in
+                // `view_window()` leaves the spinner up forever with no way to answer
+                // the new prompt, even though it's already sitting in `prompt_opt`.
+                // This same message also carries every keystroke into an
+                // already-visible field, but `authenticating` is already false
+                // whenever that's happening, so this is a no-op there.
+                if let common::Message::Prompt(_, _, Some(_)) = &common_message {
+                    self.authenticating = false;
+                }
+
                 return self.common.update(common_message);
             }
             Message::OutputEvent(output_event, output) => {


### PR DESCRIPTION
When a PAM stack has more than one interactive conversation prompt in a single login attempt (e.g. a module stacked ahead of pam_unix that asks its own question, declines, and falls through to a real password prompt), the second prompt arrives correctly over the greetd IPC channel and is stored in prompt_opt, but view_window() only renders the prompt input while !self.authenticating. authenticating is set in Message::Auth the moment the *first* prompt is answered, and is only ever cleared by Message::Login or Message::Error - never when a new prompt arrives mid-attempt. The greeter is left showing the "Authenticating..." spinner forever, with no way to answer the prompt greetd (and the PAM stack behind it) is actually waiting on.

Reset authenticating in the Message::Common handler whenever a new interactive prompt (common::Message::Prompt(_, _, Some(_))) is delegated to Common::update(). This is a no-op for the existing use of the same message to carry per-keystroke updates to an already-visible field, since authenticating is already false whenever that field can be visible/editable at all.

Disclosure: diagnosed and fixed with AI assistance (Claude) while tracking down a real login hang caused by this on my own machine, stacking a custom PAM module ahead of pam_unix under greetd. I understand the change in full; it's a single `if let` mirroring the existing Message::Login/Message::Error reset of the same flag already in this file.

- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

