### PR TITLE
feat: add PIN keypad input

### DIFF
--- a/cosmic-greeter-config/src/lib.rs
+++ b/cosmic-greeter-config/src/lib.rs
@@ -12,10 +12,19 @@ use std::num::NonZeroU32;
 pub const APP_ID: &str = "com.system76.CosmicGreeter";
 pub const CONFIG_VERSION: u64 = 1;
 
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AuthenticationInput {
+    #[default]
+    Password,
+    Pin,
+}
+
 #[derive(Debug, Clone, Default, PartialEq, CosmicConfigEntry, Deserialize, Serialize)]
 #[version = 1]
 #[id = "com.system76.CosmicGreeter"]
 pub struct Config {
+    pub default_authentication_input: AuthenticationInput,
     #[serde(skip_serializing_if = "HashMap::is_empty")]
     pub users: HashMap<NonZeroU32, user::UserState>,
     pub last_user: Option<NonZeroU32>,

--- a/i18n/en/cosmic_greeter.ftl
+++ b/i18n/en/cosmic_greeter.ftl
@@ -9,6 +9,9 @@ caps-lock = Caps Lock is active.
 enter-user = Enter name manually...
 type-username = Username:
 keyboard-layout = Keyboard layout
+hide-pin-pad = Hide numeric keypad
+pin-pad-backspace = Delete last digit
+pin-pad-submit = Submit
 restart = Restart
 restart-now = Restart now?
 restart-timeout = The system will restart automatically
@@ -27,6 +30,7 @@ shutdown-timeout = The system will shut down automatically
     *[other] in {$seconds} seconds.
   }
 suspend = Suspend
+show-pin-pad = Show numeric keypad
 user = User
 
 # Authentication errors

--- a/src/common.rs
+++ b/src/common.rs
@@ -2,12 +2,13 @@ use cosmic::app::{Core, Task};
 use cosmic::iced::core::SmolStr;
 use cosmic::iced::event::wayland::{Event as WaylandEvent, OutputEvent, SessionLockEvent};
 use cosmic::iced::event::{self};
-use cosmic::iced::keyboard::{Event as KeyEvent, Key, Modifiers};
+use cosmic::iced::keyboard::{Event as KeyEvent, Key, Modifiers, key::Named};
 use cosmic::iced::platform_specific::shell::commands::blur::blur;
 use cosmic::iced::runtime::core::window::Id as SurfaceId;
 use cosmic::iced::runtime::platform_specific::wayland::CornerRadius;
-use cosmic::iced::{self, Rectangle, Size, Subscription};
+use cosmic::iced::{self, Alignment, Length, Rectangle, Size, Subscription};
 use cosmic::surface::corner_radius::rounded_rect_strips;
+use cosmic::theme;
 use cosmic::widget::rectangle_tracker::{RectangleUpdate, rectangle_tracker_subscription};
 use cosmic::widget::{self, RectangleTracker};
 use cosmic_greeter_daemon::{BgSource, UserData};
@@ -28,6 +29,70 @@ pub struct ActiveLayout {
     pub variant: String,
 }
 
+#[derive(Debug, Default)]
+pub struct PinPadState {
+    default_visible: bool,
+    prompt: Option<(String, bool)>,
+    visible: bool,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum PinErrorHandling {
+    ClearInput,
+    PreserveInput,
+}
+
+impl PinPadState {
+    pub fn set_default_visible(&mut self, default_visible: bool) {
+        self.default_visible = default_visible;
+    }
+
+    pub fn set_prompt(&mut self, prompt: &str, secret: bool) {
+        let prompt = (prompt.to_owned(), secret);
+        if self.prompt.as_ref() != Some(&prompt) {
+            self.prompt = Some(prompt);
+            self.visible = self.default_visible && secret;
+        }
+    }
+
+    pub fn toggle(&mut self) {
+        self.visible = !self.visible;
+    }
+
+    pub fn is_visible(&self) -> bool {
+        self.visible
+    }
+
+    fn clear_input(&self, value: &mut String) -> bool {
+        if !self.visible {
+            return false;
+        }
+
+        value.clear();
+        true
+    }
+}
+
+fn pin_push_digit(value: &mut String, digit: char) {
+    if digit.is_ascii_digit() {
+        value.push(digit);
+    }
+}
+
+fn pin_backspace(value: &mut String) {
+    value.pop();
+}
+
+fn is_valid_pin(value: &str) -> bool {
+    value.chars().all(|c| c.is_ascii_digit())
+}
+
+pub(crate) const PIN_BUTTON_SIZE: f32 = 60.0;
+pub(crate) const PIN_BUTTON_ICON_SIZE: u16 = 20;
+pub(crate) const PIN_BUTTON_ICON_PADDING: f32 = (PIN_BUTTON_SIZE - 20.0) / 2.0;
+pub(crate) const PIN_PAD_SPACING: f32 = 4.0;
+pub(crate) const PIN_PAD_WIDTH: f32 = PIN_BUTTON_SIZE * 3.0 + PIN_PAD_SPACING * 2.0;
+
 pub struct Common<M> {
     pub wayland_connection: Option<Connection>,
     pub keyboard_layout: Option<ZcosmicKeyboardLayoutV1>,
@@ -47,6 +112,7 @@ pub struct Common<M> {
     pub on_session_lock_event: Option<Box<dyn Fn(SessionLockEvent) -> M>>,
     pub output_names: HashMap<WlOutput, String>,
     pub power_info_opt: Option<(widget::Icon, f64)>,
+    pub pin_pad: PinPadState,
     pub prompt_opt: Option<(String, bool, Option<String>)>,
     pub rectangle_tracker: Option<RectangleTracker<(SurfaceId, bool)>>,
     pub rectangles: HashMap<(SurfaceId, bool), iced::Rectangle>,
@@ -70,6 +136,10 @@ pub enum Message {
     SubsurfaceOpened(SurfaceId),
     OutputEvent(OutputEvent, WlOutput),
     PowerInfo(Option<(f64, bool, bool)>),
+    PinBackspace,
+    PinDigit(char),
+    PinPadToggle,
+    PinSubmit,
     Prompt(String, bool, Option<String>),
     SessionLockEvent(SessionLockEvent),
     Tick,
@@ -114,6 +184,7 @@ impl<M: From<Message> + Send + 'static> Common<M> {
             on_session_lock_event: None,
             output_names: HashMap::new(),
             power_info_opt: None,
+            pin_pad: PinPadState::default(),
             prompt_opt: None,
             subsurface_rects: HashMap::new(),
             surface_ids: HashMap::new(),
@@ -234,6 +305,22 @@ impl<M: From<Message> + Send + 'static> Common<M> {
         }
     }
 
+    pub fn handle_authentication_error(
+        &mut self,
+        error: String,
+        pin_error_handling: PinErrorHandling,
+    ) {
+        let suppress_error = match pin_error_handling {
+            PinErrorHandling::ClearInput => self
+                .prompt_opt
+                .as_mut()
+                .and_then(|(_, _, value_opt)| value_opt.as_mut())
+                .is_some_and(|value| self.pin_pad.clear_input(value)),
+            PinErrorHandling::PreserveInput => self.pin_pad.is_visible(),
+        };
+        self.error_opt = (!suppress_error).then_some(error);
+    }
+
     pub fn update(&mut self, message: Message) -> Task<M> {
         match message {
             Message::CapsLock(caps_lock) => {
@@ -250,25 +337,52 @@ impl<M: From<Message> + Send + 'static> Common<M> {
                 }
             }
             Message::Key(modifiers, key, text) => {
-                // Uncaptured keys with only shift modifiers go to the password box
-                if !modifiers.logo()
-                    && !modifiers.control()
-                    && !modifiers.alt()
-                    && matches!(key, Key::Character(_))
-                {
-                    if let Some(text) = text
-                        && let Some((_, _, Some(value))) = &mut self.prompt_opt
-                    {
-                        value.push_str(&text);
-                    }
+                if !modifiers.logo() && !modifiers.control() && !modifiers.alt() {
+                    if self.pin_pad.is_visible() {
+                        match &key {
+                            Key::Character(_) if !modifiers.shift() => {
+                                if let Some(text) = text {
+                                    for ch in text.chars() {
+                                        if ch.is_ascii_digit()
+                                            && let Some((_, _, Some(value))) = &mut self.prompt_opt
+                                        {
+                                            pin_push_digit(value, ch);
+                                        }
+                                    }
+                                }
+                            }
+                            Key::Named(Named::Backspace) => {
+                                if let Some((_, _, Some(value))) = &mut self.prompt_opt {
+                                    pin_backspace(value);
+                                }
+                            }
+                            Key::Named(Named::Enter) => {
+                                if let Some((_, true, Some(value))) = &self.prompt_opt
+                                    && !value.is_empty()
+                                {
+                                    return Task::done(cosmic::Action::App(M::from(
+                                        Message::PinSubmit,
+                                    )));
+                                }
+                            }
+                            _ => {}
+                        }
+                    } else if matches!(key, Key::Character(_)) {
+                        // Uncaptured keys with only shift modifiers go to the password box
+                        if let Some(text) = text
+                            && let Some((_, _, Some(value))) = &mut self.prompt_opt
+                        {
+                            value.push_str(&text);
+                        }
 
-                    if let Some(surface_id) = self.active_surface_id_opt
-                        && let Some(text_input_id) = self
-                            .surface_names
-                            .get(&surface_id)
-                            .and_then(|id| self.text_input_ids.get(id))
-                    {
-                        return widget::text_input::focus(text_input_id.clone());
+                        if let Some(surface_id) = self.active_surface_id_opt
+                            && let Some(text_input_id) = self
+                                .surface_names
+                                .get(&surface_id)
+                                .and_then(|id| self.text_input_ids.get(id))
+                        {
+                            return widget::text_input::focus(text_input_id.clone());
+                        }
                     }
                 }
             }
@@ -292,8 +406,32 @@ impl<M: From<Message> + Send + 'static> Common<M> {
                     self.update_battery(level, on_battery);
                 }
             }
+            Message::PinBackspace => {
+                if let Some((_, _, Some(value))) = &mut self.prompt_opt {
+                    pin_backspace(value);
+                }
+            }
+            Message::PinDigit(digit) => {
+                if let Some((_, _, Some(value))) = &mut self.prompt_opt {
+                    pin_push_digit(value, digit);
+                }
+            }
+            Message::PinPadToggle => {
+                if matches!(self.prompt_opt, Some((_, true, Some(_)))) {
+                    let was_visible = self.pin_pad.is_visible();
+                    self.pin_pad.toggle();
+                    if !was_visible
+                        && let Some((_, _, Some(value))) = &mut self.prompt_opt
+                        && !is_valid_pin(value)
+                    {
+                        value.clear();
+                    }
+                }
+            }
+            Message::PinSubmit => {}
             Message::Prompt(prompt, secret, value_opt) => {
                 let prompt_was_none = self.prompt_opt.is_none();
+                self.pin_pad.set_prompt(&prompt, secret);
                 self.prompt_opt = Some((prompt, secret, value_opt));
                 if prompt_was_none
                     && let Some(surface_id) = self.active_surface_id_opt
@@ -447,6 +585,190 @@ impl<M: From<Message> + Send + 'static> Common<M> {
         }
 
         Subscription::batch(subscriptions)
+    }
+}
+
+fn pin_digit_button<'a, M>(
+    label: &'static str,
+    digit: char,
+    enabled: bool,
+) -> cosmic::Element<'a, M>
+where
+    M: From<Message> + Clone + 'static,
+{
+    widget::button::custom(widget::text(label).size(20).center())
+        .width(Length::Fixed(PIN_BUTTON_SIZE))
+        .height(Length::Fixed(PIN_BUTTON_SIZE))
+        .on_press_maybe(enabled.then(|| Message::PinDigit(digit).into()))
+        .into()
+}
+
+fn pin_pad_row<'a, M>(children: Vec<cosmic::Element<'a, M>>) -> cosmic::Element<'a, M>
+where
+    M: Clone + 'static,
+{
+    widget::container(
+        widget::row::with_children(children)
+            .spacing(PIN_PAD_SPACING)
+            .align_y(Alignment::Center),
+    )
+    .width(Length::Fill)
+    .align_x(Alignment::Center)
+    .into()
+}
+
+pub fn pin_pad<'a, M>(value: &str, submit: M, enabled: bool) -> cosmic::Element<'a, M>
+where
+    M: From<Message> + Clone + 'static,
+{
+    let backspace_message: Option<M> =
+        (enabled && !value.is_empty()).then(|| Message::PinBackspace.into());
+    let backspace = widget::tooltip(
+        widget::button::custom(
+            widget::icon(widget::icon::from_name("edit-clear-symbolic").handle())
+                .size(PIN_BUTTON_ICON_SIZE),
+        )
+        .width(Length::Fixed(PIN_BUTTON_SIZE))
+        .height(Length::Fixed(PIN_BUTTON_SIZE))
+        .padding(PIN_BUTTON_ICON_PADDING)
+        .on_press_maybe(backspace_message),
+        widget::text(crate::fl!("pin-pad-backspace")),
+        widget::tooltip::Position::Top,
+    );
+    let submit = widget::tooltip(
+        widget::button::custom(
+            widget::icon(widget::icon::from_name("emblem-ok-symbolic").handle())
+                .size(PIN_BUTTON_ICON_SIZE),
+        )
+        .width(Length::Fixed(PIN_BUTTON_SIZE))
+        .height(Length::Fixed(PIN_BUTTON_SIZE))
+        .padding(PIN_BUTTON_ICON_PADDING)
+        .class(cosmic::theme::Button::Suggested)
+        .on_press_maybe((enabled && !value.is_empty()).then_some(submit)),
+        widget::text(crate::fl!("pin-pad-submit")),
+        widget::tooltip::Position::Top,
+    );
+
+    widget::column::with_children(vec![
+        pin_pad_row(vec![
+            pin_digit_button("1", '1', enabled),
+            pin_digit_button("2", '2', enabled),
+            pin_digit_button("3", '3', enabled),
+        ]),
+        pin_pad_row(vec![
+            pin_digit_button("4", '4', enabled),
+            pin_digit_button("5", '5', enabled),
+            pin_digit_button("6", '6', enabled),
+        ]),
+        pin_pad_row(vec![
+            pin_digit_button("7", '7', enabled),
+            pin_digit_button("8", '8', enabled),
+            pin_digit_button("9", '9', enabled),
+        ]),
+        pin_pad_row(vec![
+            backspace.into(),
+            pin_digit_button("0", '0', enabled),
+            submit.into(),
+        ]),
+    ])
+    .spacing(PIN_PAD_SPACING)
+    .width(Length::Fill)
+    .into()
+}
+
+pub fn pin_pad_mask(value: &str) -> String {
+    "•".repeat(value.chars().count())
+}
+
+pub fn pin_pad_toggle<'a, M>(visible: bool) -> cosmic::Element<'a, M>
+where
+    M: From<Message> + Clone + 'static,
+{
+    let label = if visible {
+        crate::fl!("hide-pin-pad")
+    } else {
+        crate::fl!("show-pin-pad")
+    };
+    let button = widget::button::custom(widget::icon::from_name("input-dialpad-symbolic").size(16))
+        .padding(12.0)
+        .on_press(Message::PinPadToggle.into());
+
+    widget::tooltip(button, widget::text(label), widget::tooltip::Position::Top).into()
+}
+
+pub(crate) fn pin_pad_area<'a, M>(
+    value: &str,
+    authenticating: bool,
+    submit: M,
+) -> Vec<cosmic::Element<'a, M>>
+where
+    M: From<Message> + Clone + 'static,
+{
+    let display = if authenticating {
+        widget::container(
+            widget::row::with_capacity(2)
+                .spacing(8.0)
+                .align_y(Alignment::Center)
+                .push(widget::indeterminate_circular().size(16.0).bar_height(2.0))
+                .push(widget::text(crate::fl!("authenticating"))),
+        )
+        .width(Length::Fill)
+        .height(Length::Fixed(40.0))
+        .align_x(Alignment::Center)
+        .into()
+    } else {
+        widget::container(
+            iced::widget::text_input("", &pin_pad_mask(value))
+                .align_x(Alignment::Center)
+                .width(Length::Fixed(PIN_PAD_WIDTH)),
+        )
+        .width(Length::Fill)
+        .height(Length::Fixed(40.0))
+        .align_x(Alignment::Center)
+        .into()
+    };
+
+    vec![display, pin_pad(value, submit, !authenticating)]
+}
+
+pub(crate) fn status_footer_elements<'a, M>(
+    authenticating: bool,
+    pin_pad_visible: bool,
+    error_opt: Option<&'a str>,
+    caps_lock: bool,
+) -> Vec<cosmic::Element<'a, M>>
+where
+    M: Clone + 'static,
+{
+    if authenticating && !pin_pad_visible {
+        vec![
+            widget::container(
+                widget::row::with_capacity(2)
+                    .spacing(8.0)
+                    .align_y(Alignment::Center)
+                    .push(widget::indeterminate_circular().size(16.0).bar_height(2.0))
+                    .push(widget::text(crate::fl!("authenticating"))),
+            )
+            .width(Length::Fill)
+            .align_x(Alignment::Center)
+            .into(),
+        ]
+    } else if !pin_pad_visible {
+        if let Some(error) = error_opt {
+            let mut elements = vec![
+                widget::text(error)
+                    .class(theme::Text::Color(iced::Color::from_rgb(1.0, 0.0, 0.0)))
+                    .into(),
+            ];
+            if !caps_lock {
+                elements.push(widget::text("").into());
+            }
+            elements
+        } else {
+            vec![widget::text("").into()]
+        }
+    } else {
+        vec![]
     }
 }
 

--- a/src/greeter.rs
+++ b/src/greeter.rs
@@ -716,6 +716,7 @@ impl App {
                     widget::tooltip::Position::Top
                 ),
             ];
+            button_row = button_row.push(common::pin_pad_toggle(self.common.pin_pad.is_visible()));
             if self.flags.logind_available {
                 button_row = button_row
                     .push(widget::tooltip(
@@ -770,7 +771,9 @@ impl App {
 
             // Add top spacing for better visual appearance
             // Bottom of the password text input field should align with bottom of time widget
-            column = column.push(widget::space::vertical().height(Length::Fixed(space_height)));
+            if !self.common.pin_pad.is_visible() {
+                column = column.push(widget::space::vertical().height(Length::Fixed(space_height)));
+            }
 
             match &self.socket_state {
                 SocketState::Pending => {
@@ -783,7 +786,9 @@ impl App {
                         .iter()
                         .zip(self.flags.user_icons.iter())
                     {
-                        if !self.entering_name && user_data.name == self.selected_username.username
+                        if !self.entering_name
+                            && user_data.name == self.selected_username.username
+                            && !self.common.pin_pad.is_visible()
                         {
                             // Display user icon or empty transparent box
                             if let Some(icon_handle) = user_icon {
@@ -833,7 +838,15 @@ impl App {
                         match value_opt {
                             Some(value) => {
                                 // Only show password input when not authenticating
-                                if !self.authenticating {
+                                if *secret && self.common.pin_pad.is_visible() {
+                                    for elem in common::pin_pad_area(
+                                        value,
+                                        self.authenticating,
+                                        Message::Auth(Some(value.clone())),
+                                    ) {
+                                        column = column.push(elem);
+                                    }
+                                } else if !self.authenticating {
                                     let text_input_id = self
                                         .common
                                         .surface_names
@@ -908,28 +921,13 @@ impl App {
             }
 
             // Show either authenticating message or error message in the same location
-            if self.authenticating {
-                column = column.push(
-                    widget::container(
-                        widget::row::with_capacity(2)
-                            .spacing(8.0)
-                            .align_y(Alignment::Center)
-                            .push(widget::indeterminate_circular().size(16.0).bar_height(2.0))
-                            .push(widget::text(fl!("authenticating"))),
-                    )
-                    .width(Length::Fill)
-                    .align_x(Alignment::Center),
-                );
-            } else if let Some(error) = &self.common.error_opt {
-                column = column.push(
-                    widget::text(error)
-                        .class(theme::Text::Color(iced::Color::from_rgb(1.0, 0.0, 0.0))),
-                );
-                if !self.common.caps_lock {
-                    column = column.push(widget::text(""));
-                }
-            } else {
-                column = column.push(widget::text(""));
+            for elem in common::status_footer_elements(
+                self.authenticating,
+                self.common.pin_pad.is_visible(),
+                self.common.error_opt.as_deref(),
+                self.common.caps_lock,
+            ) {
+                column = column.push(elem);
             }
 
             id_container(
@@ -1102,6 +1100,10 @@ impl cosmic::Application for App {
         core.set_app_type(cosmic::core::AppType::System);
         let mut tasks = Vec::new();
         let (mut common, common_task) = Common::init(core);
+        common.pin_pad.set_default_visible(matches!(
+            flags.greeter_config.default_authentication_input,
+            cosmic_greeter_config::AuthenticationInput::Pin
+        ));
         common.on_output_event = Some(Box::new(|output_event, output| {
             Message::OutputEvent(output_event, output)
         }));
@@ -1193,6 +1195,12 @@ impl cosmic::Application for App {
                 // appear "stuck" on the last info message.
                 if let common::Message::Prompt(_, _secret, None) = &common_message {
                     self.send_request(Request::PostAuthMessageResponse { response: None });
+                }
+                if let common::Message::PinSubmit = &common_message {
+                    if let Some((_, _, Some(value))) = &self.common.prompt_opt {
+                        return self.update(Message::Auth(Some(value.clone())));
+                    }
+                    return Task::none();
                 }
 
                 return self.common.update(common_message);
@@ -1504,7 +1512,8 @@ impl cosmic::Application for App {
             Message::AuthError(error) => {
                 // The conversation continues, so acknowledge like any other
                 // non-interactive auth message rather than cancelling the session.
-                self.common.error_opt = Some(error);
+                self.common
+                    .handle_authentication_error(error, common::PinErrorHandling::PreserveInput);
                 self.authenticating = false;
                 self.send_request(Request::PostAuthMessageResponse { response: None });
             }
@@ -1522,7 +1531,8 @@ impl cosmic::Application for App {
                 }
             }
             Message::Error(error) => {
-                self.common.error_opt = Some(error);
+                self.common
+                    .handle_authentication_error(error, common::PinErrorHandling::ClearInput);
                 self.authenticating = false;
 
                 self.send_request(Request::CancelSession);

--- a/src/locker.rs
+++ b/src/locker.rs
@@ -16,6 +16,7 @@ use cosmic::iced::{
 };
 use cosmic::{Element, executor, surface, theme, widget};
 use cosmic_config::CosmicConfigEntry;
+use cosmic_greeter_config::{AuthenticationInput, Config as CosmicGreeterConfig};
 use cosmic_greeter_daemon::{TimeAppletConfig, UserData};
 use std::any::TypeId;
 use std::ffi::{CStr, CString};
@@ -78,6 +79,7 @@ pub fn main(user: pwd::Passwd) -> Result<(), Box<dyn std::error::Error>> {
     let mut user_data = UserData::from(user);
     // We are already the user at this point
     user_data.load_config_as_user();
+    let (greeter_config, _) = CosmicGreeterConfig::load();
 
     let logind_available = cfg!(feature = "logind") && crate::logind::is_available();
 
@@ -87,6 +89,7 @@ pub fn main(user: pwd::Passwd) -> Result<(), Box<dyn std::error::Error>> {
             .take()
             .map(widget::image::Handle::from_bytes),
         user_data,
+        default_authentication_input: greeter_config.default_authentication_input,
         lockfile_opt: lockfile_opt(),
         logind_available,
     };
@@ -249,6 +252,7 @@ impl pam_client::ConversationHandler for Conversation {
 pub struct Flags {
     user_data: UserData,
     user_icon: Option<widget::image::Handle>,
+    default_authentication_input: AuthenticationInput,
     lockfile_opt: Option<PathBuf>,
     logind_available: bool,
 }
@@ -447,6 +451,7 @@ impl App {
                     widget::tooltip::Position::Top
                 ),
             ];
+            button_row = button_row.push(common::pin_pad_toggle(self.common.pin_pad.is_visible()));
             if cfg!(feature = "logind") && self.flags.logind_available {
                 button_row = button_row.push(widget::tooltip(
                     widget::button::custom(widget::icon::from_name("system-suspend-symbolic"))
@@ -481,85 +486,103 @@ impl App {
 
             // Add top spacing for better visual appearance
             // Bottom of the password text input field should align with bottom of time widget
-            column = column.push(widget::space::vertical().height(Length::Fixed(space_height)));
+            if !self.common.pin_pad.is_visible() {
+                column = column.push(widget::space::vertical().height(Length::Fixed(space_height)));
+            }
 
             // Display user icon or empty transparent box
-            if let Some(icon_handle) = &self.flags.user_icon {
-                column = column.push(
-                    widget::container(
-                        widget::image(icon_handle)
-                            .width(Length::Fixed(78.0))
-                            .height(Length::Fixed(78.0))
-                            .content_fit(iced::ContentFit::Fill),
-                    )
-                    .padding(0.0)
-                    .width(Length::Fill)
-                    .height(Length::Fixed(78.0))
-                    .align_x(Alignment::Center),
-                );
-            } else {
-                // Empty transparent box for users without icons
-                column = column.push(
-                    widget::container(widget::space::horizontal().width(Length::Fixed(78.0)))
+            if !self.common.pin_pad.is_visible() {
+                if let Some(icon_handle) = &self.flags.user_icon {
+                    column = column.push(
+                        widget::container(
+                            widget::image(icon_handle)
+                                .width(Length::Fixed(78.0))
+                                .height(Length::Fixed(78.0))
+                                .content_fit(iced::ContentFit::Fill),
+                        )
                         .padding(0.0)
                         .width(Length::Fill)
                         .height(Length::Fixed(78.0))
                         .align_x(Alignment::Center),
+                    );
+                } else {
+                    // Empty transparent box for users without icons
+                    column = column.push(
+                        widget::container(widget::space::horizontal().width(Length::Fixed(78.0)))
+                            .padding(0.0)
+                            .width(Length::Fill)
+                            .height(Length::Fixed(78.0))
+                            .align_x(Alignment::Center),
+                    );
+                }
+
+                column = column.push(
+                    widget::container(widget::text::title4(&self.flags.user_data.full_name))
+                        .width(Length::Fill)
+                        .align_x(Alignment::Center),
                 );
             }
-
-            column = column.push(
-                widget::container(widget::text::title4(&self.flags.user_data.full_name))
-                    .width(Length::Fill)
-                    .align_x(Alignment::Center),
-            );
 
             if let Some((prompt, secret, value_opt)) = &self.common.prompt_opt {
                 match value_opt {
                     Some(value) => {
-                        let text_input_id = self
-                            .common
-                            .surface_names
-                            .get(&surface_id)
-                            .and_then(|id| self.common.text_input_ids.get(id))
-                            .cloned()
-                            .unwrap_or_else(|| cosmic::widget::Id::new("text_input"));
+                        if *secret && self.common.pin_pad.is_visible() {
+                            for elem in common::pin_pad_area(
+                                value,
+                                self.authenticating,
+                                Message::Submit(value.clone()),
+                            ) {
+                                column = column.push(elem);
+                            }
+                        } else {
+                            let text_input_id = self
+                                .common
+                                .surface_names
+                                .get(&surface_id)
+                                .and_then(|id| self.common.text_input_ids.get(id))
+                                .cloned()
+                                .unwrap_or_else(|| cosmic::widget::Id::new("text_input"));
 
-                        let mut text_input = widget::secure_input(
-                            prompt.clone(),
-                            value.as_str(),
-                            Some(
-                                common::Message::Prompt(
-                                    prompt.clone(),
-                                    !*secret,
-                                    Some(value.clone()),
-                                )
-                                .into(),
-                            ),
-                            *secret,
-                        )
-                        .id(text_input_id);
+                            let mut text_input = widget::secure_input(
+                                prompt.clone(),
+                                value.as_str(),
+                                Some(
+                                    common::Message::Prompt(
+                                        prompt.clone(),
+                                        !*secret,
+                                        Some(value.clone()),
+                                    )
+                                    .into(),
+                                ),
+                                *secret,
+                            )
+                            .id(text_input_id);
 
-                        // Don't allow input when authenticating
-                        if !self.authenticating {
-                            text_input = text_input
-                                .on_input(|input| {
-                                    common::Message::Prompt(prompt.clone(), *secret, Some(input))
+                            // Don't allow input when authenticating
+                            if !self.authenticating {
+                                text_input = text_input
+                                    .on_input(|input| {
+                                        common::Message::Prompt(
+                                            prompt.clone(),
+                                            *secret,
+                                            Some(input),
+                                        )
                                         .into()
-                                })
-                                .on_submit(Message::Submit);
-                        }
+                                    })
+                                    .on_submit(Message::Submit);
+                            }
 
-                        if *secret {
-                            text_input = text_input.password()
-                        }
+                            if *secret {
+                                text_input = text_input.password()
+                            }
 
-                        column = column.push(text_input);
+                            column = column.push(text_input);
 
-                        if self.common.caps_lock && !self.authenticating {
-                            column = column.push(widget::text(fl!("caps-lock")));
-                        } else if self.common.error_opt.is_none() {
-                            column = column.push(widget::text(""));
+                            if self.common.caps_lock && !self.authenticating {
+                                column = column.push(widget::text(fl!("caps-lock")));
+                            } else if self.common.error_opt.is_none() {
+                                column = column.push(widget::text(""));
+                            }
                         }
                     }
                     None => {
@@ -569,28 +592,13 @@ impl App {
             }
 
             // Show either authenticating message or error message in the same location
-            if self.authenticating {
-                column = column.push(
-                    widget::container(
-                        widget::row::with_capacity(2)
-                            .spacing(8.0)
-                            .align_y(Alignment::Center)
-                            .push(widget::indeterminate_circular().size(16.0).bar_height(2.0))
-                            .push(widget::text(fl!("authenticating"))),
-                    )
-                    .width(Length::Fill)
-                    .align_x(Alignment::Center),
-                );
-            } else if let Some(error) = &self.common.error_opt {
-                column = column.push(
-                    widget::text(error)
-                        .class(theme::Text::Color(iced::Color::from_rgb(1.0, 0.0, 0.0))),
-                );
-                if !self.common.caps_lock {
-                    column = column.push(widget::text(""));
-                }
-            } else {
-                column = column.push(widget::text(""));
+            for elem in common::status_footer_elements(
+                self.authenticating,
+                self.common.pin_pad.is_visible(),
+                self.common.error_opt.as_deref(),
+                self.common.caps_lock,
+            ) {
+                column = column.push(elem);
             }
 
             widget::container(column)
@@ -663,6 +671,10 @@ impl cosmic::Application for App {
     fn init(mut core: Core, flags: Self::Flags) -> (Self, Task<Self::Message>) {
         core.set_app_type(cosmic::core::AppType::System);
         let (mut common, common_task) = Common::init(core);
+        common.pin_pad.set_default_visible(matches!(
+            flags.default_authentication_input,
+            AuthenticationInput::Pin
+        ));
         common.on_output_event = Some(Box::new(|output_event, output| {
             Message::OutputEvent(output_event, output)
         }));
@@ -714,6 +726,12 @@ impl cosmic::Application for App {
                 {
                     self.authenticating = false;
                     self.common.prompt_opt = None;
+                }
+                if let common::Message::PinSubmit = &common_message {
+                    if let Some((_, _, Some(value))) = &self.common.prompt_opt {
+                        return self.update(Message::Submit(value.clone()));
+                    }
+                    return Task::none();
                 }
                 return self.common.update(common_message);
             }
@@ -1092,7 +1110,8 @@ impl cosmic::Application for App {
                 self.flags.user_data.time_applet_config = config;
             }
             Message::Error(error) => {
-                self.common.error_opt = Some(error);
+                self.common
+                    .handle_authentication_error(error, common::PinErrorHandling::ClearInput);
                 self.authenticating = false;
             }
             Message::Lock => match self.state {


### PR DESCRIPTION
This adds the option for pin entry that is easier for login on touch input based devices, such as Linux phones. Also adds a config value, that allows to set password (default) or pin as the default login option for greeter and locker, so distros like postmarketOS could configure pin input as default.

If this pull request gets merged, I will open a few follow up pull requests that improve phone usability for greeter and locker further.

https://github.com/user-attachments/assets/5c6b3c09-8fab-4cd1-bb29-d3d2b181ee4f




- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

