### PR TITLE
Fix error when compiling without `logind` feature

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,37 @@
+{
+  rust-overlay ? import (import ./nix/flake-parse.nix "rust-overlay"),
+  pkgs ? import (import ./nix/flake-parse.nix "nixpkgs") {
+    system = builtins.currentSystem;
+    overlays = [ rust-overlay ];
+  },
+}:
+let
+  rustToolchain = pkgs.rust-bin.stable.latest.default.override {
+    extensions = [
+      "rust-analyzer"
+      "rust-src"
+      "llvm-tools"
+    ];
+  };
+in
+{
+  shell = import ./nix/shell.nix {
+    inherit pkgs rustToolchain;
+  };
+
+  formatter = import ./nix/formatter.nix { inherit pkgs rustToolchain; };
+
+  packages =
+    let
+      rustPlatform = pkgs.makeRustPlatform {
+        cargo = rustToolchain;
+        rustc = rustToolchain;
+      };
+    in
+    rec {
+      default = pkgs.callPackage ./nix/package.nix {
+        inherit rustPlatform;
+      };
+      sessiond-seat = default;
+    };
+}

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,45 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1788881743,
+        "narHash": "sha256-151taSq/21cxagiIu7hyMVl68+FbHfwBP4lh6TB6KOM=",
+        "rev": "d6524aaca2ff07876657ae2b323f24be4874944b",
+        "type": "tarball",
+        "url": "https://releases.nixos.org/nixos/unstable/nixos-26.11pre1069856.d6524aaca2ff/nixexprs.tar.xz"
+      },
+      "original": {
+        "type": "tarball",
+        "url": "https://channels.nixos.org/nixos-unstable/nixexprs.tar.xz"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs",
+        "rust-overlay": "rust-overlay"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1788851328,
+        "narHash": "sha256-YOwlUD0Lt/3SulKhZ7z0Jmgbq/DWh8SjnGwUlFSw+YM=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "6ae57a71bcb0bebc7a66cc2bd76942c4cf649167",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,84 @@
+{
+  inputs = {
+    nixpkgs.url = "https://channels.nixos.org/nixos-unstable/nixexprs.tar.xz";
+    rust-overlay = {
+      url = "github:oxalica/rust-overlay";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+  };
+
+  outputs =
+    {
+      self,
+      nixpkgs,
+      rust-overlay,
+      ...
+    }:
+    let
+      systems = [
+        "x86_64-linux"
+        "aarch64-linux"
+      ];
+
+      pkgsFor =
+        system:
+        import nixpkgs {
+          inherit system;
+          overlays = [ rust-overlay.overlays.default ];
+        };
+
+      forAllSystems = f: nixpkgs.lib.genAttrs systems (system: f (pkgsFor system));
+    in
+    {
+      devShells = forAllSystems (pkgs: {
+        default =
+          let
+            rustToolchain = pkgs.rust-bin.stable.latest.default.override {
+              extensions = [
+                "rust-analyzer"
+                "rust-src"
+                "llvm-tools"
+              ];
+            };
+          in
+          import ./nix/shell.nix { inherit pkgs rustToolchain; };
+      });
+
+      packages = forAllSystems (
+        pkgs:
+        let
+          rustToolchain = pkgs.rust-bin.stable.latest.default.override {
+            extensions = [
+              "rust-analyzer"
+              "rust-src"
+              "llvm-tools"
+            ];
+          };
+          rustPlatform = pkgs.makeRustPlatform {
+            cargo = rustToolchain;
+            rustc = rustToolchain;
+          };
+        in
+        {
+          cosmic-greeter = pkgs.callPackage ./nix/package.nix {
+            inherit rustPlatform;
+          };
+          default = self.packages.${pkgs.stdenv.hostPlatform.system}.cosmic-greeter;
+        }
+      );
+
+      formatter = forAllSystems (
+        pkgs:
+        let
+          rustToolchain = pkgs.rust-bin.stable.latest.default.override {
+            extensions = [
+              "rust-analyzer"
+              "rust-src"
+              "llvm-tools"
+            ];
+          };
+        in
+        import ./nix/formatter.nix { inherit pkgs rustToolchain; }
+      );
+    };
+}

--- a/nix/flake-parse.nix
+++ b/nix/flake-parse.nix
@@ -1,0 +1,12 @@
+inputName:
+let
+  lock = builtins.fromJSON (builtins.readFile ../flake.lock);
+  namedNode = lock.nodes.${lock.nodes.root.inputs.${inputName}}.locked;
+  githubTarball = fetchTarball {
+    url =
+      namedNode.url
+        or "https://github.com/${namedNode.owner}/${namedNode.repo}/archive/${namedNode.rev}.tar.gz";
+    sha256 = namedNode.narHash;
+  };
+in
+githubTarball

--- a/nix/formatter.nix
+++ b/nix/formatter.nix
@@ -1,0 +1,17 @@
+{ pkgs, rustToolchain }:
+pkgs.writeShellApplication {
+  name = "nix3-fmt-wrapper";
+  runtimeInputs = builtins.attrValues {
+    inherit (pkgs)
+      nixfmt
+      taplo
+      fd
+      ;
+    inherit rustToolchain;
+  };
+  text = ''
+    fd "$@" -t f -e nix -x nixfmt -q '{}'
+    fd "$@" -t f -e toml -x taplo format '{}'
+    cargo fmt
+  '';
+}

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -1,0 +1,108 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  rustPlatform,
+  libcosmicAppHook,
+  cmake,
+  just,
+  cosmic-randr,
+  dav1d,
+  libinput,
+  linux-pam,
+  udev,
+  coreutils,
+  xkeyboard_config,
+  nixosTests,
+  orca,
+  withLogind ? true,
+  withUpower ? true,
+  withNetworkManager ? true,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "cosmic-greeter";
+  version = "1.6.0";
+
+  src = fetchFromGitHub {
+    owner = "pop-os";
+    repo = "cosmic-greeter";
+    tag = "epoch-${finalAttrs.version}";
+    hash = "sha256-hDVdl2+7NVLA+YxO2HToni57IEr0i4OGTsYDc3YGTuw=";
+  };
+
+  postPatch = ''
+    substituteInPlace src/greeter.rs --replace-fail '/usr/bin/env' '${lib.getExe' coreutils "env"}'
+    substituteInPlace src/greeter.rs --replace-fail '/usr/bin/orca' '${lib.getExe orca}'
+  '';
+
+  cargoHash = "sha256-vHR9go8/iVUT7oBV8h+mmBvhi2oSKNBKtV0uoDOr6go=";
+
+  buildNoDefaultFeatures = true;
+
+  buildFeatures =
+    lib.optionals withLogind [ "logind" ]
+    ++ lib.optionals withUpower [ "upower" ]
+    ++ lib.optionals withNetworkManager [ "networkmanager" ];
+
+  separateDebugInfo = true;
+  __structuredAttrs = true;
+
+  env.VERGEN_GIT_SHA = finalAttrs.src.tag;
+
+  nativeBuildInputs = [
+    rustPlatform.bindgenHook
+    cmake
+    just
+    libcosmicAppHook
+  ];
+
+  buildInputs = [
+    cosmic-randr
+    dav1d
+    libinput
+    linux-pam
+    udev
+    orca
+  ];
+
+  dontUseJustBuild = true;
+  dontUseJustCheck = true;
+
+  justFlags = [
+    "--set"
+    "prefix"
+    (placeholder "out")
+    "--set"
+    "cargo-target-dir"
+    "target/${stdenv.hostPlatform.rust.cargoShortTarget}"
+  ];
+
+  preFixup = ''
+    libcosmicAppWrapperArgs+=(
+      --prefix PATH : ${lib.makeBinPath [ cosmic-randr ]}
+      --set-default X11_BASE_RULES_XML ${xkeyboard_config}/share/X11/xkb/rules/base.xml
+      --set-default X11_BASE_EXTRA_RULES_XML ${xkeyboard_config}/share/X11/xkb/rules/extra.xml
+    )
+  '';
+
+  passthru = {
+    tests = {
+      inherit (nixosTests)
+        cosmic
+        cosmic-autologin
+        cosmic-noxwayland
+        cosmic-autologin-noxwayland
+        ;
+    };
+  };
+
+  meta = {
+    homepage = "https://github.com/pop-os/cosmic-greeter";
+    description = "Greeter for the COSMIC Desktop Environment";
+    mainProgram = "cosmic-greeter";
+    license = lib.licenses.gpl3Only;
+    teams = [ lib.teams.cosmic ];
+    platforms = lib.platforms.linux;
+  };
+})

--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -1,0 +1,31 @@
+{ pkgs, rustToolchain }:
+pkgs.mkShell {
+  name = "cosmic-greeter-devshell";
+  packages = builtins.attrValues {
+    inherit
+      rustToolchain
+      ;
+    inherit (pkgs)
+      rust-analyzer-unwrapped
+      nixd
+      libxkbcommon
+      dav1d
+      libinput
+      linux-pam
+      gcc
+      glibc
+      cmake
+      ;
+    inherit (pkgs.llvmPackages)
+      libclang
+      llvm
+      ;
+  };
+
+  nativeBuildInputs = [ pkgs.pkg-config ];
+
+  RUST_SRC_PATH = "${rustToolchain}/lib/rustlib/src/rust/library";
+  LLVM_CONFIG_PATH = "${pkgs.llvmPackages.llvm}/bin/llvm-config";
+  LIBCLANG_PATH = "${pkgs.llvmPackages.libclang.lib}/lib";
+  BINDGEN_EXTRA_CLANG_ARGS = "-I${pkgs.linux-pam}/include -I${pkgs.glibc.dev}/include";
+}

--- a/src/greeter.rs
+++ b/src/greeter.rs
@@ -279,8 +279,6 @@ pub fn main() -> Result<(), Box<dyn Error>> {
         sessions
     };
 
-    let logind_available = cfg!(feature = "logind") && crate::logind::is_available();
-
     let flags = Flags {
         user_icons: user_datas
             .iter_mut()
@@ -290,7 +288,10 @@ pub fn main() -> Result<(), Box<dyn Error>> {
         sessions,
         greeter_config,
         greeter_config_handler,
-        logind_available,
+        #[cfg(feature = "logind")]
+        logind_available: crate::logind::is_available(),
+        #[cfg(not(feature = "logind"))]
+        logind_available: false,
     };
 
     let settings = Settings::default().no_main_window(true);

--- a/src/locker.rs
+++ b/src/locker.rs
@@ -79,8 +79,6 @@ pub fn main(user: pwd::Passwd) -> Result<(), Box<dyn std::error::Error>> {
     // We are already the user at this point
     user_data.load_config_as_user();
 
-    let logind_available = cfg!(feature = "logind") && crate::logind::is_available();
-
     let flags = Flags {
         user_icon: user_data
             .icon_opt
@@ -88,7 +86,10 @@ pub fn main(user: pwd::Passwd) -> Result<(), Box<dyn std::error::Error>> {
             .map(widget::image::Handle::from_bytes),
         user_data,
         lockfile_opt: lockfile_opt(),
-        logind_available,
+        #[cfg(feature = "logind")]
+        logind_available: crate::logind::is_available(),
+        #[cfg(not(feature = "logind"))]
+        logind_available: false,
     };
 
     let settings = Settings::default().no_main_window(true);
@@ -1226,7 +1227,8 @@ impl cosmic::Application for App {
             }),
         );
 
-        if cfg!(feature = "logind") && self.flags.logind_available {
+        #[cfg(feature = "logind")]
+        if self.flags.logind_available {
             subscriptions.push(crate::logind::subscription());
         }
 


### PR DESCRIPTION
`crate::logind::is_available()` function was used despite `logind` module being gated behind `logind` feature, `cfg!(feature = "logind")` was used wrongly here as it doesn't remove surrounding code from compilation.

Additionally initialized nix development shell and a nix package with support for flakes and legacy nix, let me know if it's too complicated for this repo.

- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

